### PR TITLE
[WIP] Tracking Beamer

### DIFF
--- a/src/backend/latex/document/beamer.rs
+++ b/src/backend/latex/document/beamer.rs
@@ -1,0 +1,110 @@
+use std::io::{Write, Result};
+use std::fs;
+use std::path::Path;
+
+use typed_arena::Arena;
+
+use crate::backend::Backend;
+use crate::backend::latex::{self, preamble};
+use crate::config::Config;
+use crate::generator::Generator;
+
+#[derive(Debug)]
+pub struct Beamer;
+
+impl<'a> Backend<'a> for Beamer {
+    type Text = latex::TextGen;
+    type FootnoteReference = latex::FootnoteReferenceGen;
+    type Link = latex::LinkGen;
+    type Image = latex::ImageGen;
+    type Pdf = latex::PdfGen;
+    type SoftBreak = latex::SoftBreakGen;
+    type HardBreak = latex::HardBreakGen;
+    type TableOfContents = latex::TableOfContentsGen;
+    type Bibliography = latex::BibliographyGen;
+    type ListOfTables = latex::ListOfTablesGen;
+    type ListOfFigures = latex::ListOfFiguresGen;
+    type ListOfListings = latex::ListOfListingsGen;
+    type Appendix = latex::AppendixGen;
+
+    type Paragraph = latex::ParagraphGen;
+    type Rule = latex::RuleGen;
+    type Header = latex::HeaderGen;
+    type BlockQuote = latex::BlockQuoteGen;
+    type CodeBlock = latex::CodeBlockGen;
+    type List = latex::ListGen;
+    type Enumerate = latex::EnumerateGen;
+    type Item = latex::ItemGen;
+    type FootnoteDefinition = latex::FootnoteDefinitionGen;
+    type Table = latex::TableGen;
+    type TableHead = latex::TableHeadGen;
+    type TableRow = latex::TableRowGen;
+    type TableCell = latex::TableCellGen;
+    type InlineEmphasis = latex::InlineEmphasisGen;
+    type InlineStrong = latex::InlineStrongGen;
+    type InlineCode = latex::InlineCodeGen;
+    type InlineMath = latex::InlineMathGen;
+    type Equation = latex::EquationGen;
+    type NumberedEquation = latex::NumberedEquationGen;
+    type Graphviz = latex::GraphvizGen<'a>;
+
+    fn new() -> Self {
+        Beamer
+    }
+
+    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> Result<()> {
+        write!(out, "\\documentclass[")?;
+        write!(out, "{},", cfg.fontsize)?;
+        for other in &cfg.classoptions {
+            write!(out, "{},", other)?;
+        }
+
+        // Beamer already loads internally color, hyperref, xcolor. Correct their options.
+        writeln!(out, "color={{usenames,dvipsnames}},")?;
+        writeln!(out, "xcolor={{usenames,dvipsnames}},")?;
+        writeln!(out, "hyperref={{pdfusetitle}},")?;
+
+        writeln!(out, "]{{beamer}}")?;
+        writeln!(out)?;
+
+        preamble::write_packages(cfg, out)?;
+        preamble::write_fixes(cfg, out)?;
+
+        writeln!(out)?;
+        writeln!(out, "\\def \\ifempty#1{{\\def\\temp{{#1}} \\ifx\\temp\\empty}}")?;
+
+        writeln!(out)?;
+        writeln!(out, "\\begin{{document}}")?;
+        writeln!(out)?;
+
+        fn get(o: &Option<String>) -> &str { o.as_ref().map(|s| s.as_str()).unwrap_or("") }
+        writeln!(out, "\\newcommand*{{\\getTitle}}{{{}}}", get(&cfg.title))?;
+        writeln!(out, "\\newcommand*{{\\getSubtitle}}{{{}}}", get(&cfg.subtitle))?;
+        writeln!(out, "\\newcommand*{{\\getAuthor}}{{{}}}", get(&cfg.author))?;
+        writeln!(out, "\\newcommand*{{\\getDate}}{{{}}}", get(&cfg.date))?;
+        writeln!(out, "\\newcommand*{{\\getSupervisor}}{{{}}}", get(&cfg.supervisor))?;
+        writeln!(out, "\\newcommand*{{\\getAdvisor}}{{{}}}", get(&cfg.advisor))?;
+        if let Some(logo_university) = cfg.logo_university.as_ref() {
+            writeln!(out, "\\newcommand*{{\\getLogoUniversity}}{{{}}}", logo_university.display())?;
+        } else {
+            writeln!(out, "\\newcommand*{{\\getLogoUniversity}}{{}}")?;
+        }
+        if let Some(logo_faculty) = cfg.logo_faculty.as_ref() {
+            writeln!(out, "\\newcommand*{{\\getLogoFaculty}}{{{}}}", logo_faculty.display())?;
+        } else {
+            writeln!(out, "\\newcommand*{{\\getLogoFaculty}}{{}}")?;
+        }
+        writeln!(out, "\\newcommand*{{\\getUniversity}}{{{}}}", get(&cfg.university))?;
+        writeln!(out, "\\newcommand*{{\\getFaculty}}{{{}}}", get(&cfg.faculty))?;
+        writeln!(out, "\\newcommand*{{\\getLocation}}{{{}}}", get(&cfg.location))?;
+
+        writeln!(out, "\\pagenumbering{{alph}}")?;
+
+        Ok(())
+    }
+
+    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> Result<()> {
+        writeln!(out, "\\end{{document}}")?;
+        Ok(())
+    }
+}

--- a/src/backend/latex/document/beamer/header.rs
+++ b/src/backend/latex/document/beamer/header.rs
@@ -1,0 +1,101 @@
+use std::io::{Result, Write};
+
+use crate::backend::{CodeGenUnit, Backend};
+use crate::generator::{PrimitiveGenerator, Stack};
+use crate::config::Config;
+use crate::generator::StackElement;
+use crate::generator::event::{Event, Header, Tag};
+
+/// A special beamer header generator.
+///
+/// Since subsubsections are discouraged in presentations anyways, we use these to construct
+/// frames. Each frame opens an environment that also needs to be closed. Luckily, we can intercept
+/// the end of a header where we push a new stack element to mark the open frame. Next time we
+/// encounter a header, we walk the stack to close this. Also, we need to close the last frame when
+/// the document ends.
+#[derive(Debug)]
+pub struct BeamerHeaderGen {
+    label: String,
+    frame: FrameState,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum FrameState {
+    None,
+    Begin,
+    Marker,
+}
+
+impl BeamerHeaderGen {
+    const MAGIC_HEADER: Header = Header { level: i32::max_value() };
+}
+
+impl<'a> CodeGenUnit<'a, Header> for BeamerHeaderGen {
+    fn new(_cfg: &'a Config, header: Header, gen: &mut PrimitiveGenerator<'a, impl Backend<'a>, impl Write>) -> Result<Self> {
+        // Is there a residue frame header on top? That should be the magic marker one.
+        // `take(1).last()` avoids extending the borrow on gen, `last` takes by value.
+        if let Some(StackElement::Header(_)) = gen.iter_stack().take(1).last() {
+            // Create the fitting end event.
+            let event = Event::End(Tag::Header(Self::MAGIC_HEADER));
+
+            // This should pop the header.
+            gen.visit_event(event, None)?;
+
+            if let Some(StackElement::Header(_)) = gen.iter_stack().last() {
+                panic!("Frame unexpectedly not closed");
+            }
+        }
+
+        assert!(header.level > 0);
+        let frame = if header.level < 3 {
+            write!(gen.get_out(), "\\{}section{{", "sub".repeat(header.level as usize - 1))?;
+            FrameState::None
+        } else if header.level == Self::MAGIC_HEADER.level {
+            // Oh look, the magic marker value.
+            FrameState::Marker
+        } else {
+            // Treat this as a new slide.
+            // Mark all slides as fragile, this is slower but we can use verbatim etc.
+            write!(gen.get_out(), "\\begin{{frame}}[fragile]{{")?;
+            FrameState::Begin
+        };
+
+        Ok(BeamerHeaderGen {
+            label: String::with_capacity(100),
+            frame,
+        })
+    }
+
+    fn intercept_event<'b>(&mut self, _stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>, e: Event<'a>) -> Result<Option<Event<'a>>> {
+        match &e {
+            Event::Text(text) => self.label.extend(text.chars().map(|c| match c {
+                'a'...'z' | 'A'...'Z' | '0'...'9' => c.to_ascii_lowercase(),
+                _ => '-',
+            })),
+            _ => (),
+        }
+        Ok(Some(e))
+    }
+
+    fn finish(self, gen: &mut PrimitiveGenerator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>) -> Result<()> {
+        // On marker, just write the end.
+        if self.frame == FrameState::Marker {
+            // This should be the finish event or document end?.
+            return write!(gen.get_out(), "\\end{{frame}}\n")
+        }
+
+
+        writeln!(gen.get_out(), "}}\\label{{sec:{}}}\n", self.label)?;
+        
+        if self.frame == FrameState::Begin {
+            // Create another header start, with the marker value as level.
+            let event = Event::Start(Tag::Header(Self::MAGIC_HEADER));
+
+            // We push ourselves again, this must succeed.
+            gen.visit_event(event, None).unwrap();
+        }
+
+        Ok(())
+    }
+}
+

--- a/src/backend/latex/document/beamer/mod.rs
+++ b/src/backend/latex/document/beamer/mod.rs
@@ -9,6 +9,10 @@ use crate::backend::latex::{self, preamble};
 use crate::config::Config;
 use crate::generator::Generator;
 
+mod header;
+
+pub use self::header::BeamerHeaderGen;
+
 #[derive(Debug)]
 pub struct Beamer;
 
@@ -29,7 +33,7 @@ impl<'a> Backend<'a> for Beamer {
 
     type Paragraph = latex::ParagraphGen;
     type Rule = latex::RuleGen;
-    type Header = latex::HeaderGen;
+    type Header = BeamerHeaderGen;
     type BlockQuote = latex::BlockQuoteGen;
     type CodeBlock = latex::CodeBlockGen;
     type List = latex::ListGen;

--- a/src/backend/latex/document/mod.rs
+++ b/src/backend/latex/document/mod.rs
@@ -1,5 +1,7 @@
 mod article;
+mod beamer;
 mod thesis;
 
 pub use self::article::Article;
+pub use self::beamer::Beamer;
 pub use self::thesis::Thesis;

--- a/src/backend/latex/mod.rs
+++ b/src/backend/latex/mod.rs
@@ -5,7 +5,7 @@ mod replace;
 mod simple;
 mod complex;
 
-pub use self::document::{Article, Thesis};
+pub use self::document::{Article, Beamer, Thesis};
 
 use self::simple::{TextGen, FootnoteReferenceGen, LinkGen, ImageGen, PdfGen, SoftBreakGen, HardBreakGen,
     TableOfContentsGen, BibliographyGen, ListOfTablesGen, ListOfFiguresGen, ListOfListingsGen,

--- a/src/backend/latex/preamble.rs
+++ b/src/backend/latex/preamble.rs
@@ -2,7 +2,7 @@ use std::io::{Write, Result};
 
 use isolang::Language;
 
-use crate::config::Config;
+use crate::config::{Config, DocumentType};
 
 pub fn write_packages(cfg: &Config, out: &mut impl Write) -> Result<()> {
     writeln!(out, "\\usepackage[utf8]{{inputenc}}")?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -512,14 +512,15 @@ impl FromStr for OutType {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, EnumString)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, EnumString)]
 #[serde(rename_all = "lowercase", deny_unknown_fields)]
 pub enum DocumentType {
     Article,
     Thesis,
+    Beamer,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Display, EnumString)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Display, EnumString)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[strum(serialize_all = "kebab_case")]
 pub enum CitationStyle {

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -18,9 +18,9 @@ pub mod event;
 
 pub use self::stack::Stack;
 pub use self::primitive::PrimitiveGenerator;
+pub use self::code_gen_units::StackElement;
 
 use self::concat::Concat;
-use self::code_gen_units::StackElement;
 use self::event::{Event, Image, Pdf};
 
 pub struct Generator<'a, B: Backend<'a>, W: Write> {

--- a/test/beamer.md
+++ b/test/beamer.md
@@ -54,8 +54,12 @@ digraph FancyGraph {
 
 # Includes
 
+### Wikipedia markdown image
+
 ![](https://upload.wikimedia.org/wikipedia/commons/thumb/4/48/Markdown-mark.svg/208px-Markdown-mark.svg.png)
 > -- [@wikipedia-markdown]
+
+# beamer-end-last-frame
 
 [appendix]
 

--- a/test/beamer.md
+++ b/test/beamer.md
@@ -1,0 +1,68 @@
+```pundoc
+document_type = "beamer"
+lang = "en"
+title = "Test Markdown File"
+subtitle = "Showing pundoc's Features"
+author = "Me"
+date = "\\today"
+publisher = "My Publisher"
+advisor = "My Advisor"
+supervisor = "My Supervisor"
+citestyle = "ieee"
+```
+
+# A very in-depth talk
+
+## Code Formatting
+
+### Rust
+
+Some rust code on a slide:
+
+```rust
+fn main() {
+    let foo = bar();
+}
+```
+
+### Graphviz
+
+```graphviz,label=graphviz,caption=Fancy Graph,width=0.5\textwidth,height=0.5\textwidth,scale=0.4
+digraph FancyGraph {
+    splines=ortho;
+    
+    start[label="Start Project"];
+    right_or_fast[label="Do things\nright or do\nthem fast?", shape="diamond"];
+    well[label="Code Well"]
+    done_well[label="Are you\ndone yet?", shape="diamond"];
+    away[label="Throw it all out\nand start over"];
+    fast[label="Code Fast"];
+    done_fast[label="Does it\nwork yet?", shape="diamond"];
+    
+    start -> right_or_fast;
+    right_or_fast -> well[label="Right"];
+    well -> done_well;
+    done_well -> well[label="No"];
+    done_well -> away[label="No, and the\nrequirements\nhave changed."];
+    right_or_fast -> fast[label="Fast"];
+    fast -> done_fast;
+    done_fast -> fast[label="No"];
+    done_fast -> away[label="Almost, but it's\nbecome a mass\nof kludges and\nspaghetti code."];
+    away -> start;
+}
+```
+
+# Includes
+
+![](https://upload.wikimedia.org/wikipedia/commons/thumb/4/48/Markdown-mark.svg/208px-Markdown-mark.svg.png)
+> -- [@wikipedia-markdown]
+
+[appendix]
+
+[listoflistings]
+
+[listoftables]
+
+[listoffigures]
+
+[bibliography]


### PR DESCRIPTION
- [ ] Remove the stupid hack for creating beamer frames

All headers nested 3 levels or deeper are treated as frames for the sake of beamer. Use of `subsubsection` is discouraged anyways. We could switch to `subsubsubsection` as well, that is not built into the document class afterall, but it makes creating frames less pretty. Beamer also has an internal labeling system as frame attributes that should probably be used instead of the raw `\label` mechanism.

The implemention abuses a `Tag::Header` context to keep tack of beamer frames and close their environment properly. This is an absolutely abhorrent hack, and it means there needs to be an additional non-frame header at the end of the document. 

Something like this should instead be built into the design for document classes (`Backend` impls). I'm very sorry for this being included at all but I need it kind of right now, and I didn't have time to look into the overall structure of the backend for doing the necessary rework.

- [ ] Support beamer options

Also styles and colours, all deeper customizations can be done in the document.

- [ ] Allow more control over frame options

Some way to control whether `fragile` is set, or which mechanism to use for overlays. Also, `plain` is likely useful. We could also decide to forward to pure latex code in the markdow file here.