### PR TITLE
Add a Report document class

### DIFF
--- a/src/backend/latex/document/mod.rs
+++ b/src/backend/latex/document/mod.rs
@@ -1,5 +1,7 @@
 mod article;
+mod report;
 mod thesis;
 
 pub use self::article::Article;
+pub use self::report::Report;
 pub use self::thesis::Thesis;

--- a/src/backend/latex/document/report.rs
+++ b/src/backend/latex/document/report.rs
@@ -1,0 +1,116 @@
+use std::io::{Write, Result};
+
+use crate::backend::Backend;
+use crate::backend::latex::{self, preamble};
+use crate::config::Config;
+
+#[derive(Debug)]
+pub struct Report;
+
+impl<'a> Backend<'a> for Report {
+    type Text = latex::TextGen;
+    type FootnoteReference = latex::FootnoteReferenceGen;
+    type Link = latex::LinkGen;
+    type Image = latex::ImageGen;
+    type Pdf = latex::PdfGen;
+    type SoftBreak = latex::SoftBreakGen;
+    type HardBreak = latex::HardBreakGen;
+    type TableOfContents = latex::TableOfContentsGen;
+    type Bibliography = latex::BibliographyGen;
+    type ListOfTables = latex::ListOfTablesGen;
+    type ListOfFigures = latex::ListOfFiguresGen;
+    type ListOfListings = latex::ListOfListingsGen;
+    type Appendix = latex::AppendixGen;
+
+    type Paragraph = latex::ParagraphGen;
+    type Rule = latex::RuleGen;
+    type Header = latex::BookHeaderGen;
+    type BlockQuote = latex::BlockQuoteGen;
+    type CodeBlock = latex::CodeBlockGen;
+    type List = latex::ListGen;
+    type Enumerate = latex::EnumerateGen;
+    type Item = latex::ItemGen;
+    type FootnoteDefinition = latex::FootnoteDefinitionGen;
+    type Table = latex::TableGen;
+    type TableHead = latex::TableHeadGen;
+    type TableRow = latex::TableRowGen;
+    type TableCell = latex::TableCellGen;
+    type InlineEmphasis = latex::InlineEmphasisGen;
+    type InlineStrong = latex::InlineStrongGen;
+    type InlineCode = latex::InlineCodeGen;
+    type InlineMath = latex::InlineMathGen;
+    type Equation = latex::EquationGen;
+    type NumberedEquation = latex::NumberedEquationGen;
+    type Graphviz = latex::GraphvizGen<'a>;
+
+    fn new() -> Self {
+        Report
+    }
+
+    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> Result<()> {
+        // TODO: itemizespacing
+        // documentclass
+        write!(out, "\\documentclass[")?;
+        write!(out, "{},", cfg.fontsize)?;
+        match cfg.titlepage {
+            true => write!(out, "titlepage,")?,
+            false => write!(out, "notitlepage,")?,
+        }
+        for other in &cfg.classoptions {
+            write!(out, "{},", other)?;
+        }
+        writeln!(out, "]{{scrreprt}}")?;
+        writeln!(out)?;
+
+        preamble::write_packages(cfg, out)?;
+        preamble::write_fixes(cfg, out)?;
+
+        writeln!(out)?;
+        writeln!(out, "\\begin{{document}}")?;
+        writeln!(out)?;
+
+        if let Some(title) = &cfg.title {
+            writeln!(out, "\\title{{{}}}", title)?;
+        }
+        if let Some(subtitle) = &cfg.subtitle {
+            writeln!(out, "\\subtitle{{{}}}", subtitle)?;
+        }
+        if let Some(author) = &cfg.author {
+            writeln!(out, "\\author{{{}}}", author)?;
+        }
+        if let Some(date) = &cfg.date {
+            writeln!(out, "\\date{{{}}}", date)?;
+        }
+        let publisher = match (&cfg.publisher, &cfg.supervisor, &cfg.advisor) {
+            (None, None, None) => None,
+            (a, b, c) => {
+                let mut buffer = String::new();
+                a.as_ref().map(|s| { buffer.push_str(s); buffer.push_str("\\\\"); });
+                // TODO: i18n
+                // TODO: better use table here
+                b.as_ref().map(|s| { buffer.push_str("Supervisor: "); buffer.push_str(s); buffer.push_str("\\\\"); });
+                c.as_ref().map(|s| { buffer.push_str("Advisor: "); buffer.push_str(s); buffer.push_str("\\\\"); });
+                // strip possibly leading linebreak
+                buffer.pop(); buffer.pop();
+                Some(buffer)
+            }
+        };
+        if let Some(publisher) = publisher {
+            writeln!(out, "\\publishers{{{}}}", publisher)?;
+        }
+
+        if cfg.title.is_some() {
+            // TODO: Warn if title isn't set but something else is
+            writeln!(out, "\\maketitle")?;
+        }
+        writeln!(out)?;
+
+        Ok(())
+    }
+
+    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> Result<()> {
+        writeln!(out, "\\end{{document}}")?;
+        Ok(())
+    }
+}
+

--- a/src/backend/latex/document/report.rs
+++ b/src/backend/latex/document/report.rs
@@ -66,6 +66,9 @@ impl<'a> Backend<'a> for Report {
         preamble::write_fixes(cfg, out)?;
 
         writeln!(out)?;
+        writeln!(out, "\\def \\ifempty#1{{\\ifx\\empty#1}}")?;
+
+        writeln!(out)?;
         writeln!(out, "\\begin{{document}}")?;
         writeln!(out)?;
 
@@ -99,10 +102,8 @@ impl<'a> Backend<'a> for Report {
             writeln!(out, "\\publishers{{{}}}", publisher)?;
         }
 
-        if cfg.title.is_some() {
-            // TODO: Warn if title isn't set but something else is
-            writeln!(out, "\\maketitle")?;
-        }
+        preamble::write_university_commands(&cfg, out)?;
+        writeln!(out, "{}", preamble::REPORT_COVER)?;
         writeln!(out)?;
 
         Ok(())

--- a/src/backend/latex/document/thesis.rs
+++ b/src/backend/latex/document/thesis.rs
@@ -74,27 +74,7 @@ impl<'a> Backend<'a> for Thesis {
         writeln!(out, "\\begin{{document}}")?;
         writeln!(out)?;
 
-        fn get(o: &Option<String>) -> &str { o.as_ref().map(|s| s.as_str()).unwrap_or("") }
-        writeln!(out, "\\newcommand*{{\\getTitle}}{{{}}}", get(&cfg.title))?;
-        writeln!(out, "\\newcommand*{{\\getSubtitle}}{{{}}}", get(&cfg.subtitle))?;
-        writeln!(out, "\\newcommand*{{\\getAuthor}}{{{}}}", get(&cfg.author))?;
-        writeln!(out, "\\newcommand*{{\\getDate}}{{{}}}", get(&cfg.date))?;
-        writeln!(out, "\\newcommand*{{\\getSupervisor}}{{{}}}", get(&cfg.supervisor))?;
-        writeln!(out, "\\newcommand*{{\\getAdvisor}}{{{}}}", get(&cfg.advisor))?;
-        if let Some(logo_university) = cfg.logo_university.as_ref() {
-            writeln!(out, "\\newcommand*{{\\getLogoUniversity}}{{{}}}", logo_university.display())?;
-        } else {
-            writeln!(out, "\\newcommand*{{\\getLogoUniversity}}{{}}")?;
-        }
-        if let Some(logo_faculty) = cfg.logo_faculty.as_ref() {
-            writeln!(out, "\\newcommand*{{\\getLogoFaculty}}{{{}}}", logo_faculty.display())?;
-        } else {
-            writeln!(out, "\\newcommand*{{\\getLogoFaculty}}{{}}")?;
-        }
-        writeln!(out, "\\newcommand*{{\\getUniversity}}{{{}}}", get(&cfg.university))?;
-        writeln!(out, "\\newcommand*{{\\getFaculty}}{{{}}}", get(&cfg.faculty))?;
-        writeln!(out, "\\newcommand*{{\\getThesisType}}{{{}}}", get(&cfg.thesis_type))?;
-        writeln!(out, "\\newcommand*{{\\getLocation}}{{{}}}", get(&cfg.location))?;
+        preamble::write_university_commands(&cfg, out)?;
 
         writeln!(out, "\\pagenumbering{{alph}}")?;
         writeln!(out, "{}", preamble::THESIS_COVER)?;

--- a/src/backend/latex/mod.rs
+++ b/src/backend/latex/mod.rs
@@ -5,7 +5,7 @@ mod replace;
 mod simple;
 mod complex;
 
-pub use self::document::{Article, Thesis};
+pub use self::document::{Article, Report, Thesis};
 
 use self::simple::{TextGen, FootnoteReferenceGen, LinkGen, ImageGen, PdfGen, SoftBreakGen, HardBreakGen,
     TableOfContentsGen, BibliographyGen, ListOfTablesGen, ListOfFiguresGen, ListOfListingsGen,

--- a/src/backend/latex/preamble.rs
+++ b/src/backend/latex/preamble.rs
@@ -70,6 +70,30 @@ pub fn write_fixes(cfg: &Config, out: &mut impl Write) -> Result<()> {
     Ok(())
 }
 
+pub fn write_university_commands(cfg: &Config, out: &mut impl Write) -> Result<()> {
+    fn get(o: &Option<String>) -> &str { o.as_ref().map(|s| s.as_str()).unwrap_or("") }
+    writeln!(out, "\\newcommand*{{\\getTitle}}{{{}}}", get(&cfg.title))?;
+    writeln!(out, "\\newcommand*{{\\getSubtitle}}{{{}}}", get(&cfg.subtitle))?;
+    writeln!(out, "\\newcommand*{{\\getAuthor}}{{{}}}", get(&cfg.author))?;
+    writeln!(out, "\\newcommand*{{\\getDate}}{{{}}}", get(&cfg.date))?;
+    writeln!(out, "\\newcommand*{{\\getSupervisor}}{{{}}}", get(&cfg.supervisor))?;
+    writeln!(out, "\\newcommand*{{\\getAdvisor}}{{{}}}", get(&cfg.advisor))?;
+    if let Some(logo_university) = cfg.logo_university.as_ref() {
+        writeln!(out, "\\newcommand*{{\\getLogoUniversity}}{{{}}}", logo_university.display())?;
+    } else {
+        writeln!(out, "\\newcommand*{{\\getLogoUniversity}}{{}}")?;
+    }
+    if let Some(logo_faculty) = cfg.logo_faculty.as_ref() {
+        writeln!(out, "\\newcommand*{{\\getLogoFaculty}}{{{}}}", logo_faculty.display())?;
+    } else {
+        writeln!(out, "\\newcommand*{{\\getLogoFaculty}}{{}}")?;
+    }
+    writeln!(out, "\\newcommand*{{\\getUniversity}}{{{}}}", get(&cfg.university))?;
+    writeln!(out, "\\newcommand*{{\\getFaculty}}{{{}}}", get(&cfg.faculty))?;
+    writeln!(out, "\\newcommand*{{\\getThesisType}}{{{}}}", get(&cfg.thesis_type))?;
+    writeln!(out, "\\newcommand*{{\\getLocation}}{{{}}}", get(&cfg.location))
+}
+
 // https://en.wikibooks.org/wiki/LaTeX/Source_Code_Listings
 pub const LSTSET: &'static str = r#"
 \lstset{%
@@ -293,8 +317,8 @@ pub const THESIS_TITLE: &'static str = r#"
   \end{tabular}
 
   \ifempty{\getLogoFaculty}
-  \else
     \vspace{20mm}
+  \else
     \includegraphics[height=20mm]{\getLogoFaculty}
   \fi
 \end{titlepage}
@@ -311,4 +335,55 @@ pub const THESIS_DISCLAIMER: &'static str = r#"
 \vspace{15mm}
 \noindent
 \getLocation{}, \getDate{} \hspace{50mm} \getAuthor{}
+"#;
+
+// slightly modified from THESIS_COVER from
+// https://github.com/jpbernius/tum-thesis-latex/blob/740e69c6a9671c7c0e3d74c0a70604a0ceddde56/pages/cover.tex
+pub const REPORT_COVER: &'static str = r#"
+\begin{titlepage}
+  % HACK for two-sided documents: ignore binding correction for cover page.
+  % Adapted from Markus Kohm's KOMA-Script titlepage=firstiscover handling.
+  % See http://mirrors.ctan.org/macros/latex/contrib/koma-script/scrkernel-title.dtx,
+  % \maketitle macro.
+  \oddsidemargin=\evensidemargin\relax
+  \textwidth=\dimexpr\paperwidth-2\evensidemargin-2in\relax
+  \hsize=\textwidth\relax
+
+  \centering
+
+  \ifempty{\getLogoUniversity}
+    \vspace*{20mm}
+  \else
+    \includegraphics[height=20mm]{\getLogoUniversity}
+  \fi
+
+  \vspace{5mm}
+  \ifempty{\getFaculty}
+    \vspace*{1em}
+  \else
+    {\huge\MakeUppercase{\getFaculty}}\\
+  \fi
+
+  \vspace{5mm}
+  {\large\MakeUppercase{\getUniversity}}\\
+
+  \vspace{15mm}
+  {\huge\bfseries \getTitle{}}
+
+  \vspace{5mm}
+  \ifempty{\getSubtitle}
+    {\huge\vspace{1em}}
+  \else
+    {\huge\bfseries \getSubtitle{}}
+  \fi
+
+  \vspace{15mm}
+  {\LARGE \getAuthor{}}
+
+  \ifempty{\getLogoFaculty}
+    \vspace{20mm}
+  \else
+    \includegraphics[height=20mm]{\getLogoFaculty}
+  \fi
+\end{titlepage}
 "#;

--- a/src/backend/latex/replace.rs
+++ b/src/backend/latex/replace.rs
@@ -9,6 +9,7 @@
 // manually delete duplicate characters (just fix the unreachable pattern warnings)
 pub fn replace(c: char) -> Option<&'static str> {
     Some(match c {
+        '#' => "\\#",
         '𝐴' => "$A$",
         '𝐵' => "$B$",
         '𝐶' => "$C$",

--- a/src/backend/latex/replace.rs
+++ b/src/backend/latex/replace.rs
@@ -9,7 +9,6 @@
 // manually delete duplicate characters (just fix the unreachable pattern warnings)
 pub fn replace(c: char) -> Option<&'static str> {
     Some(match c {
-        '#' => "\\#",
         '𝐴' => "$A$",
         '𝐵' => "$B$",
         '𝐶' => "$C$",

--- a/src/backend/latex/simple.rs
+++ b/src/backend/latex/simple.rs
@@ -28,6 +28,7 @@ impl<'a> MediumCodeGenUnit<Cow<'a, str>> for TextGen {
             match c {
                 '_' if in_inline_code => s.push_str("\\char`_"),
                 '_' if !in_code_or_math => s.push_str("\\_"),
+                '#' if in_inline_code => s.push_str("\\#"),
                 '\\' if in_inline_code => s.push_str("\\textbackslash{}"),
                 c => match replace(c) {
                     Some(rep) => s.push_str(strfn(rep)),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -516,6 +516,7 @@ impl FromStr for OutType {
 #[serde(rename_all = "lowercase", deny_unknown_fields)]
 pub enum DocumentType {
     Article,
+    Report,
     Thesis,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ mod generator;
 mod backend;
 
 use crate::config::{Config, CliArgs, FileConfig, OutType, DocumentType};
-use crate::backend::latex::{Article, Thesis};
+use crate::backend::latex::{Article, Report, Thesis};
 
 fn main() {
     let args = CliArgs::from_args();
@@ -95,6 +95,8 @@ fn gen(cfg: &Config, markdown: String, out: impl Write) {
     match cfg.document_type {
         DocumentType::Article =>
             backend::generate(cfg, Article, &Arena::new(), markdown, out).unwrap(),
+        DocumentType::Report =>
+            backend::generate(cfg, Report, &Arena::new(), markdown, out).unwrap(),
         DocumentType::Thesis =>
             backend::generate(cfg, Thesis, &Arena::new(), markdown, out).unwrap(),
     }


### PR DESCRIPTION
Roughly speaking, report has the structural units (headers) of book with the simpler content of article. Also fixes the replacement of `#` which is a control char in latex. That would for example cause interesting problems when having text such as

```text
We replace all `#define` with proper `enum` types.
```