### PR TITLE
Add alt-text and title to links / images

### DIFF
--- a/src/backend/latex/preamble.rs
+++ b/src/backend/latex/preamble.rs
@@ -28,6 +28,7 @@ pub fn write_packages(cfg: &Config, out: &mut impl Write) -> Result<()> {
         writeln!(out, "\\addbibresource{{{}}}", bibliography.display())?;
     }
 
+    writeln!(out, "\\usepackage{{cmap}}")?;
     writeln!(out, "\\usepackage{{float}}")?;
     // TODO: use minted instead of lstlistings?
     // TODO: do we want scrhack?
@@ -40,15 +41,16 @@ pub fn write_packages(cfg: &Config, out: &mut impl Write) -> Result<()> {
     writeln!(out, "\\usepackage{{amsmath}}")?;
     // TODO: graphicspath
     writeln!(out, "\\usepackage{{graphicx}}")?;
+    writeln!(out, "\\usepackage{{transparent}}")?;
     writeln!(out, "\\usepackage[final]{{microtype}}")?;
     writeln!(out, "\\usepackage[pdfusetitle]{{hyperref}}")?;
-    writeln!(out, "\\usepackage{{caption}}")?;
     writeln!(out, "\\usepackage{{caption}}")?;
     // TODO: cleveref options
     writeln!(out, "\\usepackage{{cleveref}}")?;
     writeln!(out, "\\usepackage{{refcount}}")?;
     writeln!(out, "\\usepackage[titletoc,toc,title]{{appendix}}")?;
     writeln!(out, "\\usepackage{{array}}")?;
+    writeln!(out, "\\usepackage{{pdfcomment}}")?;
     writeln!(out)?;
     Ok(())
 }
@@ -62,6 +64,7 @@ pub fn write_fixes(cfg: &Config, out: &mut impl Write) -> Result<()> {
     writeln!(out, "{}", THICKHLINE)?;
     writeln!(out, "{}", AQUOTE)?;
     writeln!(out, "{}", FIX_INCLUDEGRAPHICS)?;
+    writeln!(out, "{}", IMAGE_WITH_TEXT)?;
     writeln!(out, "{}", SCALE_TIKZ_PICTURE_TO_WIDTH)?;
     // TODO: figures inline? https://tex.stackexchange.com/a/11342 last codeblock
     // with package float and `[H]`
@@ -221,6 +224,20 @@ pub const FIX_INCLUDEGRAPHICS: &'static str = r#"
 \makeatother
 
 \setkeys{Gin}{width=\ScaleWidthIfNeeded,height=\ScaleHeightIfNeeded,keepaspectratio}
+"#;
+
+// https://tex.stackexchange.com/a/75104
+pub const IMAGE_WITH_TEXT: &'static str = r#"
+\newsavebox\imagebox
+\newcommand*{\imagewithtext}[3][]{%
+  \sbox\imagebox{\includegraphics[{#1}]{#2}}%
+  \usebox\imagebox
+  \llap{%
+    \resizebox{\wd\imagebox}{\height}{%
+      \texttransparent{0}{#3}%
+    }%
+  }%
+}
 "#;
 
 // https://tex.stackexchange.com/q/183699

--- a/src/frontend/event.rs
+++ b/src/frontend/event.rs
@@ -100,6 +100,9 @@ pub struct Table<'a> {
 pub struct Include<'a> {
     pub label: Option<Cow<'a, str>>,
     pub caption: Option<Cow<'a, str>>,
+    pub title: Option<Cow<'a, str>>,
+    /// rendered already
+    pub alt_text: Option<String>,
     pub dst: Cow<'a, str>,
     pub scale: Option<Cow<'a, str>>,
     pub width: Option<Cow<'a, str>>,

--- a/src/frontend/refs.rs
+++ b/src/frontend/refs.rs
@@ -13,9 +13,10 @@ pub enum Link<'a> {
     BiberSingle(Cow<'a, str>, Option<Cow<'a, str>>),
     /// Vec<(reference, attributes)>
     BiberMultiple(Vec<(Cow<'a, str>, Option<Cow<'a, str>>)>),
-    Url(Cow<'a, str>),
-    /// destination, content (already converted)
-    UrlWithContent(Cow<'a, str>, String),
+    /// destination, title
+    Url(Cow<'a, str>, Option<Cow<'a, str>>),
+    /// destination, content (already converted), title
+    UrlWithContent(Cow<'a, str>, String, Option<Cow<'a, str>>),
     /// label, uppercase
     InterLink(Cow<'a, str>, bool),
     /// label, uppercase, content (already converted)
@@ -33,9 +34,10 @@ pub enum ReferenceParseResult<'a> {
 pub fn parse_references<'a>(cfg: &'a Config, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>, content: String) -> ReferenceParseResult<'a> {
     // ShortcutUnknown and ReferenceUnknown make destination lowercase, but save original case in title
     let mut dst = match typ {
-        LinkType::ShortcutUnknown | LinkType::ReferenceUnknown => title,
+        LinkType::ShortcutUnknown | LinkType::ReferenceUnknown => title.clone(),
         _ => dst,
     };
+    let title = if title.is_empty() { None } else { Some(title) };
 
     dst.trim_left_inplace();
 
@@ -105,11 +107,11 @@ pub fn parse_references<'a>(cfg: &'a Config, typ: LinkType, dst: Cow<'a, str>, t
             LinkType::Autolink
             | LinkType::Shortcut | LinkType::ShortcutUnknown
             | LinkType::Collapsed | LinkType::CollapsedUnknown => {
-                ReferenceParseResult::Link(Link::Url(dst))
+                ReferenceParseResult::Link(Link::Url(dst, title))
             }
             LinkType::Reference | LinkType::ReferenceUnknown
             | LinkType::Inline => {
-                ReferenceParseResult::Link(Link::UrlWithContent(dst, content))
+                ReferenceParseResult::Link(Link::UrlWithContent(dst, content, title))
             }
         }
     }

--- a/src/generator/event.rs
+++ b/src/generator/event.rs
@@ -66,6 +66,8 @@ pub enum Tag<'a> {
 pub struct Image<'a> {
     pub label: Option<Cow<'a, str>>,
     pub caption: Option<Cow<'a, str>>,
+    pub title: Option<Cow<'a, str>>,
+    pub alt_text: Option<String>,
     /// Path to read image from.
     pub path: PathBuf,
     pub scale: Option<Cow<'a, str>>,

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -134,15 +134,17 @@ impl<'a, B: Backend<'a>, W: Write> Generator<'a, B, W> {
                 Ok(None)
             }
             Include::Image(path) => {
-                let (label, caption, scale, width, height) =
-                    if let Some(FeInclude { label, caption, dst: _dst, scale, width, height }) = image {
-                        (label, caption, scale, width, height)
+                let (label, caption, title, alt_text, scale, width, height) =
+                    if let Some(FeInclude { label, caption, title, alt_text, dst: _dst, scale, width, height }) = image {
+                        (label, caption, title, alt_text, scale, width, height)
                     } else {
                         Default::default()
                     };
                 Ok(Some(Event::Image(Image {
                     label,
                     caption,
+                    title,
+                    alt_text,
                     path,
                     scale,
                     width,

--- a/test.md
+++ b/test.md
@@ -127,7 +127,7 @@ A collapsed link to a section [#fun-with-references][].
 This is hopefully an image with a title which is used as label, such that I can reference it here as [#placeholdit].
 
 {#placeholdit,nofigure, caption = "Caption with \\"quotes\\" and , comma"}
-![Foobar](https://placehold.it/100x100.png)
+![This is a fancy alt-text](https://placehold.it/100x100.png "placeholdit image")
 ![placeholditimage]
 
 [placeholditimage]: https://placehold.it/100x100.png


### PR DESCRIPTION
Fix #18 

The overlaid transparent text on top of the image for the alt-text works perfectly fine with zathura (mupdf backend), okular, evince, pdfjs and pdftotext.

`\pdftooltip` on the other hand works with none of the above. According to some comments it works in Adobe Reader and a different Windows pdf reader. I don't know if we should waste time on this though. Apparently hover events are highly reader-implementation specific and there isn't really much that latex can do here. There are some other possibilities to use here from the `pdfcomment` package (see its [documentation](http://texdoc.net/texmf-dist/doc/latex/pdfcomment/pdfcomment.pdf), but IMO link titles shouldn't be visible by default (unless hovered over or clicked on or something similar) (cc @moritzuehling )

Edit: For tooltips there is also <https://tex.stackexchange.com/a/164186>, but that is quite some blob of latex.