### PR TITLE
Allow input files in the config to contain links

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,11 @@ fn main() {
 
     let tmpdir = TempDir::new("heradoc").expect("can't create tempdir");
     let cfg = Config::new(args, infile, file, &tmpdir);
-    clear_dir(&cfg.out_dir).expect("can't clear output directory");
+    if cfg.out_dir != cfg.temp_dir {
+        // While initializing the config, some files may already be downloaded.
+        // Thus we must only clear the output directory if it's not a temporary directory.
+        clear_dir(&cfg.out_dir).expect("can't clear output directory");
+    }
     println!("{:#?}", cfg);
 
     match cfg.output_type {

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use url::Url;
 
 mod include;
-mod remote;
+pub mod remote;
 mod source;
 
 pub use self::include::*;


### PR DESCRIPTION
Resolve referenced input files in config both to input
file dir and current working dir.

For a usage example see https://github.com/oberien/heradoc/blob/examples/examples/thesis/thesis.md