### PR TITLE
Error reporting, major refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 [[package]]
 name = "codespan"
 version = "0.2.1"
-source = "git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4#bc89c40c7169843bd9319368cd683b5fe7be47f4"
+source = "git+https://github.com/oberien/codespan?rev=dc7b13739165fc58721415ce3120d05cf117ca81#dc7b13739165fc58721415ce3120d05cf117ca81"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -172,9 +172,9 @@ dependencies = [
 [[package]]
 name = "codespan-reporting"
 version = "0.2.1"
-source = "git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4#bc89c40c7169843bd9319368cd683b5fe7be47f4"
+source = "git+https://github.com/oberien/codespan?rev=dc7b13739165fc58721415ce3120d05cf117ca81#dc7b13739165fc58721415ce3120d05cf117ca81"
 dependencies = [
- "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",
+ "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=dc7b13739165fc58721415ce3120d05cf117ca81)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -395,8 +395,8 @@ version = "0.1.0"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",
- "codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",
+ "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=dc7b13739165fc58721415ce3120d05cf117ca81)",
+ "codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=dc7b13739165fc58721415ce3120d05cf117ca81)",
  "enum-kinds 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "isolang 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1614,8 +1614,8 @@ dependencies = [
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)" = "<none>"
-"checksum codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)" = "<none>"
+"checksum codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=dc7b13739165fc58721415ce3120d05cf117ca81)" = "<none>"
+"checksum codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=dc7b13739165fc58721415ce3120d05cf117ca81)" = "<none>"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 [[package]]
 name = "codespan"
 version = "0.2.1"
-source = "git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2#dc909ed02d22dd81e04f92ca4d652a3e130418d2"
+source = "git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4#bc89c40c7169843bd9319368cd683b5fe7be47f4"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -172,9 +172,9 @@ dependencies = [
 [[package]]
 name = "codespan-reporting"
 version = "0.2.1"
-source = "git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2#dc909ed02d22dd81e04f92ca4d652a3e130418d2"
+source = "git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4#bc89c40c7169843bd9319368cd683b5fe7be47f4"
 dependencies = [
- "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)",
+ "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -385,8 +385,8 @@ name = "heradoc"
 version = "0.1.0"
 dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)",
- "codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)",
+ "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",
+ "codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "isolang 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1577,8 +1577,8 @@ dependencies = [
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)" = "<none>"
-"checksum codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)" = "<none>"
+"checksum codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)" = "<none>"
+"checksum codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)" = "<none>"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan"
+version = "0.2.1"
+source = "git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2#dc909ed02d22dd81e04f92ca4d652a3e130418d2"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.2.1"
+source = "git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2#dc909ed02d22dd81e04f92ca4d652a3e130418d2"
+dependencies = [
+ "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +241,11 @@ dependencies = [
 [[package]]
 name = "dtoa"
 version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -362,6 +385,8 @@ name = "heradoc"
 version = "0.1.0"
 dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)",
+ "codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "isolang 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -476,6 +501,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1544,6 +1577,8 @@ dependencies = [
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)" = "<none>"
+"checksum codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=dc909ed02d22dd81e04f92ca4d652a3e130418d2)" = "<none>"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
@@ -1552,6 +1587,7 @@ dependencies = [
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
+"checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum encoding_rs 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)" = "065f4d0c826fdaef059ac45487169d918558e3cf86c9d89f6e81cf52369126e5"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
@@ -1577,6 +1613,7 @@ dependencies = [
 "checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum isolang 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5855a5a1ba5957e064977b94e5cd15ecbe83904a5191576be11615186cd868"
+"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-kinds"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +397,7 @@ dependencies = [
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",
  "codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",
+ "enum-kinds 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "isolang 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -790,6 +800,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -811,6 +829,14 @@ dependencies = [
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "quote"
@@ -1126,6 +1152,16 @@ dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1590,6 +1626,7 @@ dependencies = [
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum encoding_rs 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)" = "065f4d0c826fdaef059ac45487169d918558e3cf86c9d89f6e81cf52369126e5"
+"checksum enum-kinds 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f21c374dea848c19071b1504ca5ad03c9ad0d03d2e509e68f6623b8fcac4b5"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
@@ -1648,9 +1685,11 @@ dependencies = [
 "checksum phf_generator 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "03dc191feb9b08b0dc1330d6549b795b9d81aec19efe6b4a45aec8d4caee0c4b"
 "checksum phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+"checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum pulldown-cmark 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa4987312f985c300f4d68d208a9e4b646268140b6dbe83388c09652cc19ed3f"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+"checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum quoted-string 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aea1125b7d7fc2022e6a4dc4dc8ae36ebeef1668f3c037512582d3795a5c154c"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
@@ -1690,6 +1729,7 @@ dependencies = [
 "checksum structopt-derive 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "17ff01fe96de9d16e7372ae5f19dd7ece2c703b51043c3db9ea27f9e393ea311"
 "checksum strum 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c3a2071519ab6a48f465808c4c1ffdd00dfc8e93111d02b4fc5abab177676e"
 "checksum strum_macros 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8baacebd7b7c9b864d83a6ba7a246232983e277b86fa5cdec77f565715a4b136"
+"checksum syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97c05b8ebc34ddd6b967994d5c6e9852fa92f8b82b3858c39451f97346dcce5"
 "checksum syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4439ee8325b4e4b57e59309c3724c9a4478eaeb4eb094b6f3fac180a3b2876"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
 name = "heradoc"
 version = "0.1.0"
 dependencies = [
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",
  "codespan-reporting 0.2.1 (git+https://github.com/oberien/codespan?rev=bc89c40c7169843bd9319368cd683b5fe7be47f4)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ quoted-string = "0.6.0"
 codespan = { git = "https://github.com/oberien/codespan", rev = "bc89c40c7169843bd9319368cd683b5fe7be47f4" }
 codespan-reporting = { git = "https://github.com/oberien/codespan", rev = "bc89c40c7169843bd9319368cd683b5fe7be47f4" }
 backtrace = "0.3.14"
+enum-kinds = "0.4.1"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ regex = "1.1.0"
 lazy_static = "1.2.0"
 single = "1.0.0"
 quoted-string = "0.6.0"
+codespan = { git = "https://github.com/oberien/codespan", rev = "dc909ed02d22dd81e04f92ca4d652a3e130418d2" }
+codespan-reporting = { git = "https://github.com/oberien/codespan", rev = "dc909ed02d22dd81e04f92ca4d652a3e130418d2" }
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ regex = "1.1.0"
 lazy_static = "1.2.0"
 single = "1.0.0"
 quoted-string = "0.6.0"
-codespan = { git = "https://github.com/oberien/codespan", rev = "dc909ed02d22dd81e04f92ca4d652a3e130418d2" }
-codespan-reporting = { git = "https://github.com/oberien/codespan", rev = "dc909ed02d22dd81e04f92ca4d652a3e130418d2" }
+codespan = { git = "https://github.com/oberien/codespan", rev = "bc89c40c7169843bd9319368cd683b5fe7be47f4" }
+codespan-reporting = { git = "https://github.com/oberien/codespan", rev = "bc89c40c7169843bd9319368cd683b5fe7be47f4" }
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ single = "1.0.0"
 quoted-string = "0.6.0"
 codespan = { git = "https://github.com/oberien/codespan", rev = "bc89c40c7169843bd9319368cd683b5fe7be47f4" }
 codespan-reporting = { git = "https://github.com/oberien/codespan", rev = "bc89c40c7169843bd9319368cd683b5fe7be47f4" }
+backtrace = "0.3.14"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ regex = "1.1.0"
 lazy_static = "1.2.0"
 single = "1.0.0"
 quoted-string = "0.6.0"
-codespan = { git = "https://github.com/oberien/codespan", rev = "bc89c40c7169843bd9319368cd683b5fe7be47f4" }
-codespan-reporting = { git = "https://github.com/oberien/codespan", rev = "bc89c40c7169843bd9319368cd683b5fe7be47f4" }
+codespan = { git = "https://github.com/oberien/codespan", rev = "dc7b13739165fc58721415ce3120d05cf117ca81" }
+codespan-reporting = { git = "https://github.com/oberien/codespan", rev = "dc7b13739165fc58721415ce3120d05cf117ca81" }
 backtrace = "0.3.14"
 enum-kinds = "0.4.1"
 

--- a/examples/errors.md
+++ b/examples/errors.md
@@ -10,3 +10,7 @@ nothing here yet
 {foo=bar}
 
 text text text
+
+{#section-label}
+
+# Section {#section-label2}

--- a/examples/errors.md
+++ b/examples/errors.md
@@ -2,3 +2,11 @@
 ```rust, #label2
 let foo = bar;
 ```
+
+```sequence
+nothing here yet
+```
+
+{foo=bar}
+
+text text text

--- a/examples/errors.md
+++ b/examples/errors.md
@@ -1,5 +1,5 @@
 {#label}
-```rust, #label2
+```rust, #label2, figure=true, nofigure, figure
 let foo = bar;
 ```
 

--- a/examples/errors.md
+++ b/examples/errors.md
@@ -1,0 +1,4 @@
+{#label}
+```rust, #label2
+let foo = bar;
+```

--- a/examples/functionality/codeblocks.md
+++ b/examples/functionality/codeblocks.md
@@ -2,7 +2,7 @@
 
 ## Rust
 
-```rust
+```rust, caption = "\"foo\""
 fn main() {
     let foo = bar();
 }

--- a/src/backend/latex/complex/blockquote.rs
+++ b/src/backend/latex/complex/blockquote.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::Event;
 use crate::generator::Generator;
 
@@ -14,7 +14,7 @@ pub struct BlockQuoteGen {
 
 impl<'a> CodeGenUnit<'a, ()> for BlockQuoteGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _tag: WithRange<()>,
         _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(BlockQuoteGen { quote: Vec::new() })
@@ -26,7 +26,7 @@ impl<'a> CodeGenUnit<'a, ()> for BlockQuoteGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         let out = gen.get_out();
         let quote = String::from_utf8(self.quote).expect("invalid UTF8");

--- a/src/backend/latex/complex/blockquote.rs
+++ b/src/backend/latex/complex/blockquote.rs
@@ -1,10 +1,11 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::generator::Generator;
-
 use crate::generator::event::Event;
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct BlockQuoteGen {
@@ -13,7 +14,7 @@ pub struct BlockQuoteGen {
 
 impl<'a> CodeGenUnit<'a, ()> for BlockQuoteGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(BlockQuoteGen { quote: Vec::new() })
     }
@@ -23,7 +24,7 @@ impl<'a> CodeGenUnit<'a, ()> for BlockQuoteGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         let quote = String::from_utf8(self.quote).expect("invalid UTF8");

--- a/src/backend/latex/complex/blockquote.rs
+++ b/src/backend/latex/complex/blockquote.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::Event;
 use crate::error::Result;
+use crate::generator::event::Event;
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct BlockQuoteGen {
@@ -14,7 +14,8 @@ pub struct BlockQuoteGen {
 
 impl<'a> CodeGenUnit<'a, ()> for BlockQuoteGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(BlockQuoteGen { quote: Vec::new() })
     }
@@ -24,7 +25,8 @@ impl<'a> CodeGenUnit<'a, ()> for BlockQuoteGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         let quote = String::from_utf8(self.quote).expect("invalid UTF8");

--- a/src/backend/latex/complex/codeblock.rs
+++ b/src/backend/latex/complex/codeblock.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::{CodeBlock, Event};
 use crate::error::Result;
+use crate::generator::event::{CodeBlock, Event};
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct CodeBlockGen;
@@ -34,7 +34,8 @@ impl<'a> CodeGenUnit<'a, CodeBlock<'a>> for CodeBlockGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\end{{lstlisting}}")?;
         Ok(())

--- a/src/backend/latex/complex/codeblock.rs
+++ b/src/backend/latex/complex/codeblock.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{CodeBlock, Event};
 use crate::generator::Generator;
 
@@ -12,20 +12,20 @@ pub struct CodeBlockGen;
 
 impl<'a> CodeGenUnit<'a, CodeBlock<'a>> for CodeBlockGen {
     fn new(
-        _cfg: &'a Config, code_block: CodeBlock<'a>, _range: Range<usize>,
+        _cfg: &'a Config, code_block: WithRange<CodeBlock<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let CodeBlock { label, caption, language } = code_block;
+        let WithRange(CodeBlock { label, caption, language }, _range) = code_block;
 
         let out = gen.get_out();
         write!(out, "\\begin{{lstlisting}}[")?;
-        if let Some((label, _)) = label {
+        if let Some(WithRange(label, _)) = label {
             write!(out, "label={{{}}},", label)?;
         }
-        if let Some((caption, _)) = caption {
+        if let Some(WithRange(caption, _)) = caption {
             write!(out, "caption={{{}}},", caption)?;
         }
-        if let Some((language, _)) = language {
+        if let Some(WithRange(language, _)) = language {
             write!(out, "language={{{}}},", language)?;
         }
         writeln!(out, "]")?;
@@ -35,7 +35,7 @@ impl<'a> CodeGenUnit<'a, CodeBlock<'a>> for CodeBlockGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\end{{lstlisting}}")?;
         Ok(())

--- a/src/backend/latex/complex/codeblock.rs
+++ b/src/backend/latex/complex/codeblock.rs
@@ -19,13 +19,13 @@ impl<'a> CodeGenUnit<'a, CodeBlock<'a>> for CodeBlockGen {
 
         let out = gen.get_out();
         write!(out, "\\begin{{lstlisting}}[")?;
-        if let Some(label) = label {
+        if let Some((label, _)) = label {
             write!(out, "label={{{}}},", label)?;
         }
-        if let Some(caption) = caption {
+        if let Some((caption, _)) = caption {
             write!(out, "caption={{{}}},", caption)?;
         }
-        if let Some(language) = language {
+        if let Some((language, _)) = language {
             write!(out, "language={{{}}},", language)?;
         }
         writeln!(out, "]")?;

--- a/src/backend/latex/complex/codeblock.rs
+++ b/src/backend/latex/complex/codeblock.rs
@@ -1,16 +1,18 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::{CodeBlock, Event};
 use crate::generator::Generator;
+use crate::generator::event::{CodeBlock, Event};
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct CodeBlockGen;
 
 impl<'a> CodeGenUnit<'a, CodeBlock<'a>> for CodeBlockGen {
     fn new(
-        _cfg: &'a Config, code_block: CodeBlock<'a>,
+        _cfg: &'a Config, code_block: CodeBlock<'a>, _range: Range<usize>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let CodeBlock { label, caption, language } = code_block;
@@ -32,7 +34,7 @@ impl<'a> CodeGenUnit<'a, CodeBlock<'a>> for CodeBlockGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\end{{lstlisting}}")?;
         Ok(())

--- a/src/backend/latex/complex/figure.rs
+++ b/src/backend/latex/complex/figure.rs
@@ -6,9 +6,9 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::{Event, Figure};
 use crate::error::Result;
+use crate::generator::event::{Event, Figure};
+use crate::generator::Generator;
 
 #[derive(Debug)]
 #[doc(hidden)]
@@ -44,7 +44,8 @@ pub struct AnyFigureGen<'a, T: Environment> {
 
 impl<'a, T: Environment + Debug> CodeGenUnit<'a, Figure<'a>> for AnyFigureGen<'a, T> {
     fn new(
-        _cfg: &'a Config, figure: Figure<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, figure: Figure<'a>, _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Figure { label, caption } = figure;
         write!(gen.get_out(), "\\begin{{{}}}", T::to_str())?;
@@ -52,7 +53,8 @@ impl<'a, T: Environment + Debug> CodeGenUnit<'a, Figure<'a>> for AnyFigureGen<'a
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         match self.caption {

--- a/src/backend/latex/complex/figure.rs
+++ b/src/backend/latex/complex/figure.rs
@@ -37,8 +37,8 @@ pub type TableFigureGen<'a> = AnyFigureGen<'a, Table>;
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct AnyFigureGen<'a, T: Environment> {
-    label: Option<Cow<'a, str>>,
-    caption: Option<Cow<'a, str>>,
+    label: Option<(Cow<'a, str>, Range<usize>)>,
+    caption: Option<(Cow<'a, str>, Range<usize>)>,
     _marker: PhantomData<T>,
 }
 
@@ -56,10 +56,10 @@ impl<'a, T: Environment + Debug> CodeGenUnit<'a, Figure<'a>> for AnyFigureGen<'a
     ) -> Result<()> {
         let out = gen.get_out();
         match self.caption {
-            Some(caption) => writeln!(out, "\\caption{{{}}}", caption)?,
+            Some((caption, _)) => writeln!(out, "\\caption{{{}}}", caption)?,
             None => writeln!(out, "\\caption{{}}")?,
         }
-        if let Some(label) = self.label {
+        if let Some((label, _)) = self.label {
             writeln!(out, "\\label{{{}}}", label)?;
         }
         writeln!(out, "\\end{{{}}}", T::to_str())?;

--- a/src/backend/latex/complex/figure.rs
+++ b/src/backend/latex/complex/figure.rs
@@ -2,11 +2,11 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 use std::io::Write;
 use std::marker::PhantomData;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{Event, Figure};
 use crate::generator::Generator;
 
@@ -37,31 +37,31 @@ pub type TableFigureGen<'a> = AnyFigureGen<'a, Table>;
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct AnyFigureGen<'a, T: Environment> {
-    label: Option<(Cow<'a, str>, Range<usize>)>,
-    caption: Option<(Cow<'a, str>, Range<usize>)>,
+    label: Option<WithRange<Cow<'a, str>>>,
+    caption: Option<WithRange<Cow<'a, str>>>,
     _marker: PhantomData<T>,
 }
 
 impl<'a, T: Environment + Debug> CodeGenUnit<'a, Figure<'a>> for AnyFigureGen<'a, T> {
     fn new(
-        _cfg: &'a Config, figure: Figure<'a>, _range: Range<usize>,
+        _cfg: &'a Config, figure: WithRange<Figure<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let Figure { label, caption } = figure;
+        let WithRange(Figure { label, caption }, _range) = figure;
         write!(gen.get_out(), "\\begin{{{}}}", T::to_str())?;
         Ok(AnyFigureGen { label, caption, _marker: PhantomData })
     }
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         let out = gen.get_out();
         match self.caption {
-            Some((caption, _)) => writeln!(out, "\\caption{{{}}}", caption)?,
+            Some(WithRange(caption, _)) => writeln!(out, "\\caption{{{}}}", caption)?,
             None => writeln!(out, "\\caption{{}}")?,
         }
-        if let Some((label, _)) = self.label {
+        if let Some(WithRange(label, _)) = self.label {
             writeln!(out, "\\label{{{}}}", label)?;
         }
         writeln!(out, "\\end{{{}}}", T::to_str())?;

--- a/src/backend/latex/complex/figure.rs
+++ b/src/backend/latex/complex/figure.rs
@@ -1,13 +1,14 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
-use std::io::{Result, Write};
+use std::io::Write;
 use std::marker::PhantomData;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::generator::Generator;
-
 use crate::generator::event::{Event, Figure};
+use crate::error::Result;
 
 #[derive(Debug)]
 #[doc(hidden)]
@@ -43,7 +44,7 @@ pub struct AnyFigureGen<'a, T: Environment> {
 
 impl<'a, T: Environment + Debug> CodeGenUnit<'a, Figure<'a>> for AnyFigureGen<'a, T> {
     fn new(
-        _cfg: &'a Config, figure: Figure<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, figure: Figure<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Figure { label, caption } = figure;
         write!(gen.get_out(), "\\begin{{{}}}", T::to_str())?;
@@ -51,7 +52,7 @@ impl<'a, T: Environment + Debug> CodeGenUnit<'a, Figure<'a>> for AnyFigureGen<'a
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         match self.caption {

--- a/src/backend/latex/complex/footnote_definition.rs
+++ b/src/backend/latex/complex/footnote_definition.rs
@@ -1,17 +1,18 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::generator::Generator;
-
 use crate::generator::event::{Event, FootnoteDefinition};
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct FootnoteDefinitionGen;
 
 impl<'a> CodeGenUnit<'a, FootnoteDefinition<'a>> for FootnoteDefinitionGen {
     fn new(
-        _cfg: &'a Config, fnote: FootnoteDefinition<'a>,
+        _cfg: &'a Config, fnote: FootnoteDefinition<'a>, _range: Range<usize>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let FootnoteDefinition { label } = fnote;
@@ -22,7 +23,7 @@ impl<'a> CodeGenUnit<'a, FootnoteDefinition<'a>> for FootnoteDefinitionGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "}}")?;
         Ok(())

--- a/src/backend/latex/complex/footnote_definition.rs
+++ b/src/backend/latex/complex/footnote_definition.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::{Event, FootnoteDefinition};
 use crate::error::Result;
+use crate::generator::event::{Event, FootnoteDefinition};
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct FootnoteDefinitionGen;
@@ -23,7 +23,8 @@ impl<'a> CodeGenUnit<'a, FootnoteDefinition<'a>> for FootnoteDefinitionGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "}}")?;
         Ok(())

--- a/src/backend/latex/complex/footnote_definition.rs
+++ b/src/backend/latex/complex/footnote_definition.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{Event, FootnoteDefinition};
 use crate::generator::Generator;
 
@@ -12,10 +12,10 @@ pub struct FootnoteDefinitionGen;
 
 impl<'a> CodeGenUnit<'a, FootnoteDefinition<'a>> for FootnoteDefinitionGen {
     fn new(
-        _cfg: &'a Config, fnote: FootnoteDefinition<'a>, _range: Range<usize>,
+        _cfg: &'a Config, fnote: WithRange<FootnoteDefinition<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let FootnoteDefinition { label } = fnote;
+        let WithRange(FootnoteDefinition { label }, _range) = fnote;
         // TODO: Add pass to get all definitions to put definition on the same site as the first
         // reference
         write!(gen.get_out(), "\\footnotetext{{\\label{{fnote:{}}}", label)?;
@@ -24,7 +24,7 @@ impl<'a> CodeGenUnit<'a, FootnoteDefinition<'a>> for FootnoteDefinitionGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "}}")?;
         Ok(())

--- a/src/backend/latex/complex/graphviz.rs
+++ b/src/backend/latex/complex/graphviz.rs
@@ -1,13 +1,15 @@
 use std::fs::File;
-use std::io::{Result, Write};
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
+use std::ops::Range;
 
 use crate::backend::latex::InlineEnvironment;
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::{Event, Graphviz};
 use crate::generator::Generator;
+use crate::generator::event::{Event, Graphviz};
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct GraphvizGen<'a> {
@@ -18,7 +20,7 @@ pub struct GraphvizGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Graphviz<'a>> for GraphvizGen<'a> {
     fn new(
-        cfg: &Config, graphviz: Graphviz<'a>,
+        cfg: &Config, graphviz: Graphviz<'a>, _range: Range<usize>,
         _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let mut i = 0;
@@ -37,7 +39,7 @@ impl<'a> CodeGenUnit<'a, Graphviz<'a>> for GraphvizGen<'a> {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         drop(self.file);
         let Graphviz { label, caption, scale, width, height } = self.graphviz;

--- a/src/backend/latex/complex/graphviz.rs
+++ b/src/backend/latex/complex/graphviz.rs
@@ -1,6 +1,5 @@
 use std::fs::{File, OpenOptions};
 use std::io::{ErrorKind, Write};
-use std::ops::Range;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -8,6 +7,7 @@ use crate::backend::latex::InlineEnvironment;
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::{Error, Result};
+use crate::frontend::range::{SourceRange, WithRange};
 use crate::generator::event::{Event, Graphviz};
 use crate::generator::Generator;
 
@@ -16,14 +16,15 @@ pub struct GraphvizGen<'a> {
     path: PathBuf,
     file: File,
     graphviz: Graphviz<'a>,
-    range: Range<usize>,
+    range: SourceRange,
 }
 
 impl<'a> CodeGenUnit<'a, Graphviz<'a>> for GraphvizGen<'a> {
     fn new(
-        cfg: &Config, graphviz: Graphviz<'a>, range: Range<usize>,
+        cfg: &Config, graphviz: WithRange<Graphviz<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
+        let WithRange(graphviz, range) = graphviz;
         let mut i = 0;
         let (file, path) = loop {
             let p = cfg.out_dir.join(format!("graphviz_{}", i));
@@ -37,7 +38,7 @@ impl<'a> CodeGenUnit<'a, Graphviz<'a>> for GraphvizGen<'a> {
                 Err(e) => {
                     gen.diagnostics()
                         .bug("error creating temporary graphviz file")
-                        .with_info_section(&range, "for this graphviz code")
+                        .with_info_section(range, "for this graphviz code")
                         .note(format!("cause: {}", e))
                         .note("skipping over it")
                         .emit();
@@ -59,7 +60,7 @@ impl<'a> CodeGenUnit<'a, Graphviz<'a>> for GraphvizGen<'a> {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         drop(self.file);
         let Graphviz { label, caption, scale, width, height } = self.graphviz;
@@ -75,7 +76,7 @@ impl<'a> CodeGenUnit<'a, Graphviz<'a>> for GraphvizGen<'a> {
             // TODO: parse the dot output and provide appropriate error messages
             gen.diagnostics()
                 .error("graphviz rendering failed")
-                .with_error_section(&self.range, "trying to render this graphviz cdoe block")
+                .with_error_section(self.range, "trying to render this graphviz cdoe block")
                 .note(format!("`dot` returned error code {:?}", out.status.code()))
                 .note("logs written to dot_stdout.log and dot_stderr.log")
                 .note("skipping over it")
@@ -87,13 +88,13 @@ impl<'a> CodeGenUnit<'a, Graphviz<'a>> for GraphvizGen<'a> {
         inline_fig.write_begin(&mut *out)?;
 
         write!(out, "\\includegraphics[")?;
-        if let Some((scale, _)) = scale {
+        if let Some(WithRange(scale, _)) = scale {
             write!(out, "scale={},", scale)?;
         }
-        if let Some((width, _)) = width {
+        if let Some(WithRange(width, _)) = width {
             write!(out, "width={},", width)?;
         }
-        if let Some((height, _)) = height {
+        if let Some(WithRange(height, _)) = height {
             write!(out, "height={},", height)?;
         }
         writeln!(out, "]{{{}.pdf}}", self.path.display())?;

--- a/src/backend/latex/complex/header.rs
+++ b/src/backend/latex/complex/header.rs
@@ -4,9 +4,9 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::{Event, Header};
 use crate::error::Result;
+use crate::generator::event::{Event, Header};
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct HeaderGen<'a> {
@@ -15,7 +15,8 @@ pub struct HeaderGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Header<'a>> for HeaderGen<'a> {
     fn new(
-        _cfg: &'a Config, header: Header<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, header: Header<'a>, _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Header { label, level } = header;
         assert!(level >= 0, "Header level should be positive, but is {}", level);
@@ -24,7 +25,8 @@ impl<'a> CodeGenUnit<'a, Header<'a>> for HeaderGen<'a> {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label.0)?;
         Ok(())
@@ -38,7 +40,8 @@ pub struct BookHeaderGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Header<'a>> for BookHeaderGen<'a> {
     fn new(
-        _cfg: &'a Config, header: Header<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, header: Header<'a>, _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Header { label, level } = header;
         assert!(level >= 0, "Header level should be positive, but is {}", level);
@@ -51,7 +54,8 @@ impl<'a> CodeGenUnit<'a, Header<'a>> for BookHeaderGen<'a> {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label.0)?;
         Ok(())

--- a/src/backend/latex/complex/header.rs
+++ b/src/backend/latex/complex/header.rs
@@ -1,24 +1,24 @@
 use std::borrow::Cow;
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{Event, Header};
 use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct HeaderGen<'a> {
-    label: (Cow<'a, str>, Range<usize>),
+    label: WithRange<Cow<'a, str>>,
 }
 
 impl<'a> CodeGenUnit<'a, Header<'a>> for HeaderGen<'a> {
     fn new(
-        _cfg: &'a Config, header: Header<'a>, _range: Range<usize>,
+        _cfg: &'a Config, header: WithRange<Header<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let Header { label, level } = header;
+        let WithRange(Header { label, level }, _range) = header;
         assert!(level >= 0, "Header level should be positive, but is {}", level);
         write!(gen.get_out(), "\\{}section{{", "sub".repeat(level as usize - 1))?;
         Ok(HeaderGen { label })
@@ -26,7 +26,7 @@ impl<'a> CodeGenUnit<'a, Header<'a>> for HeaderGen<'a> {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label.0)?;
         Ok(())
@@ -35,15 +35,15 @@ impl<'a> CodeGenUnit<'a, Header<'a>> for HeaderGen<'a> {
 
 #[derive(Debug)]
 pub struct BookHeaderGen<'a> {
-    label: (Cow<'a, str>, Range<usize>),
+    label: WithRange<Cow<'a, str>>,
 }
 
 impl<'a> CodeGenUnit<'a, Header<'a>> for BookHeaderGen<'a> {
     fn new(
-        _cfg: &'a Config, header: Header<'a>, _range: Range<usize>,
+        _cfg: &'a Config, header: WithRange<Header<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let Header { label, level } = header;
+        let WithRange(Header { label, level }, _range) = header;
         assert!(level >= 0, "Header level should be positive, but is {}", level);
         if level == 1 {
             write!(gen.get_out(), "\\chapter{{")?;
@@ -55,7 +55,7 @@ impl<'a> CodeGenUnit<'a, Header<'a>> for BookHeaderGen<'a> {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label.0)?;
         Ok(())

--- a/src/backend/latex/complex/header.rs
+++ b/src/backend/latex/complex/header.rs
@@ -1,10 +1,12 @@
 use std::borrow::Cow;
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::{Event, Header};
 use crate::generator::Generator;
+use crate::generator::event::{Event, Header};
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct HeaderGen<'a> {
@@ -13,7 +15,7 @@ pub struct HeaderGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Header<'a>> for HeaderGen<'a> {
     fn new(
-        _cfg: &'a Config, header: Header<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, header: Header<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Header { label, level } = header;
         assert!(level >= 0, "Header level should be positive, but is {}", level);
@@ -22,7 +24,7 @@ impl<'a> CodeGenUnit<'a, Header<'a>> for HeaderGen<'a> {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label)?;
         Ok(())
@@ -36,7 +38,7 @@ pub struct BookHeaderGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Header<'a>> for BookHeaderGen<'a> {
     fn new(
-        _cfg: &'a Config, header: Header<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, header: Header<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Header { label, level } = header;
         assert!(level >= 0, "Header level should be positive, but is {}", level);
@@ -49,7 +51,7 @@ impl<'a> CodeGenUnit<'a, Header<'a>> for BookHeaderGen<'a> {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label)?;
         Ok(())

--- a/src/backend/latex/complex/header.rs
+++ b/src/backend/latex/complex/header.rs
@@ -10,7 +10,7 @@ use crate::error::Result;
 
 #[derive(Debug)]
 pub struct HeaderGen<'a> {
-    label: Cow<'a, str>,
+    label: (Cow<'a, str>, Range<usize>),
 }
 
 impl<'a> CodeGenUnit<'a, Header<'a>> for HeaderGen<'a> {
@@ -26,14 +26,14 @@ impl<'a> CodeGenUnit<'a, Header<'a>> for HeaderGen<'a> {
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
-        writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label)?;
+        writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label.0)?;
         Ok(())
     }
 }
 
 #[derive(Debug)]
 pub struct BookHeaderGen<'a> {
-    label: Cow<'a, str>,
+    label: (Cow<'a, str>, Range<usize>),
 }
 
 impl<'a> CodeGenUnit<'a, Header<'a>> for BookHeaderGen<'a> {
@@ -53,7 +53,7 @@ impl<'a> CodeGenUnit<'a, Header<'a>> for BookHeaderGen<'a> {
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
-        writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label)?;
+        writeln!(gen.get_out(), "}}\\label{{{}}}\n", self.label.0)?;
         Ok(())
     }
 }

--- a/src/backend/latex/complex/htmlblock.rs
+++ b/src/backend/latex/complex/htmlblock.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::Event;
 use crate::generator::Generator;
 
@@ -13,7 +13,7 @@ pub struct HtmlBlockGen;
 // TODO: Not sure what to do here. Blind passthrough (current)? Panic? Error? Warn?
 impl<'a> CodeGenUnit<'a, ()> for HtmlBlockGen {
     fn new(
-        _cfg: &'a Config, (): (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(HtmlBlockGen)
@@ -21,7 +21,7 @@ impl<'a> CodeGenUnit<'a, ()> for HtmlBlockGen {
 
     fn finish(
         self, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         Ok(())
     }

--- a/src/backend/latex/complex/htmlblock.rs
+++ b/src/backend/latex/complex/htmlblock.rs
@@ -1,9 +1,11 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::Event;
 use crate::generator::Generator;
+use crate::generator::event::Event;
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct HtmlBlockGen;
@@ -11,13 +13,13 @@ pub struct HtmlBlockGen;
 // TODO: Not sure what to do here. Blind passthrough (current)? Panic? Error? Warn?
 impl<'a> CodeGenUnit<'a, ()> for HtmlBlockGen {
     fn new(
-        _cfg: &'a Config, (): (), _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, (): (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(HtmlBlockGen)
     }
 
     fn finish(
-        self, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         Ok(())
     }

--- a/src/backend/latex/complex/htmlblock.rs
+++ b/src/backend/latex/complex/htmlblock.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::Event;
 use crate::error::Result;
+use crate::generator::event::Event;
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct HtmlBlockGen;
@@ -13,13 +13,15 @@ pub struct HtmlBlockGen;
 // TODO: Not sure what to do here. Blind passthrough (current)? Panic? Error? Warn?
 impl<'a> CodeGenUnit<'a, ()> for HtmlBlockGen {
     fn new(
-        _cfg: &'a Config, (): (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, (): (), _range: Range<usize>,
+        _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(HtmlBlockGen)
     }
 
     fn finish(
-        self, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         Ok(())
     }

--- a/src/backend/latex/complex/inline.rs
+++ b/src/backend/latex/complex/inline.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::Event;
 use crate::generator::Generator;
 
@@ -12,7 +12,7 @@ pub struct InlineEmphasisGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineEmphasisGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\emph{{")?;
@@ -21,7 +21,7 @@ impl<'a> CodeGenUnit<'a, ()> for InlineEmphasisGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())
@@ -33,7 +33,7 @@ pub struct InlineStrongGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineStrongGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\textbf{{")?;
@@ -42,7 +42,7 @@ impl<'a> CodeGenUnit<'a, ()> for InlineStrongGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())
@@ -54,7 +54,7 @@ pub struct InlineStrikethroughGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineStrikethroughGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\sout{{")?;
@@ -63,7 +63,7 @@ impl<'a> CodeGenUnit<'a, ()> for InlineStrikethroughGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())
@@ -75,7 +75,7 @@ pub struct InlineCodeGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineCodeGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\texttt{{")?;
@@ -84,7 +84,7 @@ impl<'a> CodeGenUnit<'a, ()> for InlineCodeGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())

--- a/src/backend/latex/complex/inline.rs
+++ b/src/backend/latex/complex/inline.rs
@@ -1,23 +1,25 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::Event;
 use crate::generator::Generator;
+use crate::generator::event::Event;
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct InlineEmphasisGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineEmphasisGen {
     fn new(
-        _cfg: &'a Config, _tag: (), gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\emph{{")?;
         Ok(InlineEmphasisGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())
@@ -29,14 +31,14 @@ pub struct InlineStrongGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineStrongGen {
     fn new(
-        _cfg: &'a Config, _tag: (), gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\textbf{{")?;
         Ok(InlineStrongGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())
@@ -48,14 +50,14 @@ pub struct InlineStrikethroughGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineStrikethroughGen {
     fn new(
-        _cfg: &'a Config, _tag: (), gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\sout{{")?;
         Ok(InlineStrikethroughGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())
@@ -67,14 +69,14 @@ pub struct InlineCodeGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineCodeGen {
     fn new(
-        _cfg: &'a Config, _tag: (), gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\texttt{{")?;
         Ok(InlineCodeGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())

--- a/src/backend/latex/complex/inline.rs
+++ b/src/backend/latex/complex/inline.rs
@@ -3,23 +3,25 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::Event;
 use crate::error::Result;
+use crate::generator::event::Event;
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct InlineEmphasisGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineEmphasisGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\emph{{")?;
         Ok(InlineEmphasisGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())
@@ -31,14 +33,16 @@ pub struct InlineStrongGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineStrongGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\textbf{{")?;
         Ok(InlineStrongGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())
@@ -50,14 +54,16 @@ pub struct InlineStrikethroughGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineStrikethroughGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\sout{{")?;
         Ok(InlineStrikethroughGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())
@@ -69,14 +75,16 @@ pub struct InlineCodeGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineCodeGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\texttt{{")?;
         Ok(InlineCodeGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())

--- a/src/backend/latex/complex/link.rs
+++ b/src/backend/latex/complex/link.rs
@@ -1,10 +1,12 @@
 use std::borrow::Cow;
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::{Event, InterLink, Url};
 use crate::generator::Generator;
+use crate::generator::event::{Event, InterLink, Url};
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct UrlWithContentGen<'a> {
@@ -13,7 +15,7 @@ pub struct UrlWithContentGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Url<'a>> for UrlWithContentGen<'a> {
     fn new(
-        _cfg: &'a Config, url: Url<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, url: Url<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Url { destination, title } = url;
         let out = gen.get_out();
@@ -27,7 +29,7 @@ impl<'a> CodeGenUnit<'a, Url<'a>> for UrlWithContentGen<'a> {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
 
@@ -44,7 +46,7 @@ pub struct InterLinkWithContentGen;
 
 impl<'a> CodeGenUnit<'a, InterLink<'a>> for InterLinkWithContentGen {
     fn new(
-        _cfg: &'a Config, interlink: InterLink<'a>,
+        _cfg: &'a Config, interlink: InterLink<'a>, _range: Range<usize>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let InterLink { label, uppercase: _ } = interlink;
@@ -53,7 +55,7 @@ impl<'a> CodeGenUnit<'a, InterLink<'a>> for InterLinkWithContentGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())

--- a/src/backend/latex/complex/link.rs
+++ b/src/backend/latex/complex/link.rs
@@ -4,9 +4,9 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::{Event, InterLink, Url};
 use crate::error::Result;
+use crate::generator::event::{Event, InterLink, Url};
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct UrlWithContentGen<'a> {
@@ -15,7 +15,8 @@ pub struct UrlWithContentGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Url<'a>> for UrlWithContentGen<'a> {
     fn new(
-        _cfg: &'a Config, url: Url<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, url: Url<'a>, _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Url { destination, title } = url;
         let out = gen.get_out();
@@ -29,7 +30,8 @@ impl<'a> CodeGenUnit<'a, Url<'a>> for UrlWithContentGen<'a> {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
 
@@ -55,7 +57,8 @@ impl<'a> CodeGenUnit<'a, InterLink<'a>> for InterLinkWithContentGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())

--- a/src/backend/latex/complex/link.rs
+++ b/src/backend/latex/complex/link.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{Event, InterLink, Url};
 use crate::generator::Generator;
 
@@ -15,10 +15,10 @@ pub struct UrlWithContentGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Url<'a>> for UrlWithContentGen<'a> {
     fn new(
-        _cfg: &'a Config, url: Url<'a>, _range: Range<usize>,
+        _cfg: &'a Config, url: WithRange<Url<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let Url { destination, title } = url;
+        let WithRange(Url { destination, title }, _range) = url;
         let out = gen.get_out();
 
         if title.is_some() {
@@ -31,7 +31,7 @@ impl<'a> CodeGenUnit<'a, Url<'a>> for UrlWithContentGen<'a> {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         let out = gen.get_out();
 
@@ -48,17 +48,17 @@ pub struct InterLinkWithContentGen;
 
 impl<'a> CodeGenUnit<'a, InterLink<'a>> for InterLinkWithContentGen {
     fn new(
-        _cfg: &'a Config, interlink: InterLink<'a>, _range: Range<usize>,
+        _cfg: &'a Config, interlink: WithRange<InterLink<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let InterLink { label, uppercase: _ } = interlink;
+        let WithRange(InterLink { label, uppercase: _ }, _range) = interlink;
         write!(gen.get_out(), "\\hyperref[{}]{{", label)?;
         Ok(InterLinkWithContentGen)
     }
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         write!(gen.get_out(), "}}")?;
         Ok(())

--- a/src/backend/latex/complex/list.rs
+++ b/src/backend/latex/complex/list.rs
@@ -3,23 +3,25 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::{Enumerate, Event};
 use crate::error::Result;
+use crate::generator::event::{Enumerate, Event};
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct ListGen;
 
 impl<'a> CodeGenUnit<'a, ()> for ListGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         writeln!(gen.get_out(), "\\begin{{itemize}}")?;
         Ok(ListGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\end{{itemize}}")?;
         Ok(())
@@ -50,7 +52,8 @@ impl<'a> CodeGenUnit<'a, Enumerate> for EnumerateGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\end{{enumerate}}")?;
         Ok(())
@@ -62,14 +65,16 @@ pub struct ItemGen;
 
 impl<'a> CodeGenUnit<'a, ()> for ItemGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\item ")?;
         Ok(ItemGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out())?;
         Ok(())

--- a/src/backend/latex/complex/list.rs
+++ b/src/backend/latex/complex/list.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{Enumerate, Event};
 use crate::generator::Generator;
 
@@ -12,7 +12,7 @@ pub struct ListGen;
 
 impl<'a> CodeGenUnit<'a, ()> for ListGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         writeln!(gen.get_out(), "\\begin{{itemize}}")?;
@@ -21,7 +21,7 @@ impl<'a> CodeGenUnit<'a, ()> for ListGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\end{{itemize}}")?;
         Ok(())
@@ -33,10 +33,10 @@ pub struct EnumerateGen;
 
 impl<'a> CodeGenUnit<'a, Enumerate> for EnumerateGen {
     fn new(
-        _cfg: &'a Config, enumerate: Enumerate, _range: Range<usize>,
+        _cfg: &'a Config, enumerate: WithRange<Enumerate>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let Enumerate { start_number } = enumerate;
+        let WithRange(Enumerate { start_number }, _range) = enumerate;
         assert!(std::mem::size_of::<usize>() >= 4);
         assert!(start_number < i32::max_value() as usize);
         let start = start_number as i32 - 1;
@@ -53,7 +53,7 @@ impl<'a> CodeGenUnit<'a, Enumerate> for EnumerateGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\end{{enumerate}}")?;
         Ok(())
@@ -65,7 +65,7 @@ pub struct ItemGen;
 
 impl<'a> CodeGenUnit<'a, ()> for ItemGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\item ")?;
@@ -74,7 +74,7 @@ impl<'a> CodeGenUnit<'a, ()> for ItemGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         writeln!(gen.get_out())?;
         Ok(())

--- a/src/backend/latex/complex/list.rs
+++ b/src/backend/latex/complex/list.rs
@@ -1,25 +1,28 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::{Enumerate, Event};
 use crate::generator::Generator;
+use crate::generator::event::{Enumerate, Event};
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct ListGen;
 
 impl<'a> CodeGenUnit<'a, ()> for ListGen {
     fn new(
-        _cfg: &'a Config, _tag: (), gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         writeln!(gen.get_out(), "\\begin{{itemize}}")?;
         Ok(ListGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
-        writeln!(gen.get_out(), "\\end{{itemize}}")
+        writeln!(gen.get_out(), "\\end{{itemize}}")?;
+        Ok(())
     }
 }
 
@@ -28,7 +31,7 @@ pub struct EnumerateGen;
 
 impl<'a> CodeGenUnit<'a, Enumerate> for EnumerateGen {
     fn new(
-        _cfg: &'a Config, enumerate: Enumerate,
+        _cfg: &'a Config, enumerate: Enumerate, _range: Range<usize>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Enumerate { start_number } = enumerate;
@@ -47,9 +50,10 @@ impl<'a> CodeGenUnit<'a, Enumerate> for EnumerateGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
-        writeln!(gen.get_out(), "\\end{{enumerate}}")
+        writeln!(gen.get_out(), "\\end{{enumerate}}")?;
+        Ok(())
     }
 }
 
@@ -58,14 +62,14 @@ pub struct ItemGen;
 
 impl<'a> CodeGenUnit<'a, ()> for ItemGen {
     fn new(
-        _cfg: &'a Config, _tag: (), gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\item ")?;
         Ok(ItemGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out())?;
         Ok(())

--- a/src/backend/latex/complex/math.rs
+++ b/src/backend/latex/complex/math.rs
@@ -4,23 +4,25 @@ use std::ops::Range;
 use crate::backend::latex::InlineEnvironment;
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::{Equation, Event};
 use crate::error::Result;
+use crate::generator::event::{Equation, Event};
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct InlineMathGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineMathGen {
     fn new(
-        _cfg: &Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &Config, _tag: (), _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\begin{{math}}")?;
         Ok(InlineMathGen)
     }
 
     fn finish(
-        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "\\end{{math}}")?;
         Ok(())
@@ -34,7 +36,8 @@ pub struct EquationGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Equation<'a>> for EquationGen<'a> {
     fn new(
-        _cfg: &Config, eq: Equation<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &Config, eq: Equation<'a>, _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Equation { label, caption } = eq;
         let inline_fig = InlineEnvironment::new_figure(label, caption);
@@ -47,7 +50,8 @@ impl<'a> CodeGenUnit<'a, Equation<'a>> for EquationGen<'a> {
     }
 
     fn finish(
-        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         write!(out, "\\end{{align*}}")?;
@@ -63,7 +67,8 @@ pub struct NumberedEquationGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Equation<'a>> for NumberedEquationGen<'a> {
     fn new(
-        _cfg: &Config, eq: Equation<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &Config, eq: Equation<'a>, _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Equation { label, caption } = eq;
         let inline_fig = InlineEnvironment::new_figure(label, caption);
@@ -75,7 +80,8 @@ impl<'a> CodeGenUnit<'a, Equation<'a>> for NumberedEquationGen<'a> {
     }
 
     fn finish(
-        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         writeln!(out, "\\end{{align}}")?;

--- a/src/backend/latex/complex/math.rs
+++ b/src/backend/latex/complex/math.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::latex::InlineEnvironment;
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{Equation, Event};
 use crate::generator::Generator;
 
@@ -13,7 +13,7 @@ pub struct InlineMathGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineMathGen {
     fn new(
-        _cfg: &Config, _tag: (), _range: Range<usize>,
+        _cfg: &Config, _: WithRange<()>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\begin{{math}}")?;
@@ -22,7 +22,7 @@ impl<'a> CodeGenUnit<'a, ()> for InlineMathGen {
 
     fn finish(
         self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         write!(gen.get_out(), "\\end{{math}}")?;
         Ok(())
@@ -36,10 +36,10 @@ pub struct EquationGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Equation<'a>> for EquationGen<'a> {
     fn new(
-        _cfg: &Config, eq: Equation<'a>, _range: Range<usize>,
+        _cfg: &Config, eq: WithRange<Equation<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let Equation { label, caption } = eq;
+        let WithRange(Equation { label, caption }, _range) = eq;
         let inline_fig = InlineEnvironment::new_figure(label, caption);
         let out = gen.get_out();
         inline_fig.write_begin(&mut *out)?;
@@ -51,7 +51,7 @@ impl<'a> CodeGenUnit<'a, Equation<'a>> for EquationGen<'a> {
 
     fn finish(
         self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         let out = gen.get_out();
         write!(out, "\\end{{align*}}")?;
@@ -67,10 +67,10 @@ pub struct NumberedEquationGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Equation<'a>> for NumberedEquationGen<'a> {
     fn new(
-        _cfg: &Config, eq: Equation<'a>, _range: Range<usize>,
+        _cfg: &Config, eq: WithRange<Equation<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let Equation { label, caption } = eq;
+        let WithRange(Equation { label, caption }, _range) = eq;
         let inline_fig = InlineEnvironment::new_figure(label, caption);
         let out = gen.get_out();
         inline_fig.write_begin(&mut *out)?;
@@ -81,7 +81,7 @@ impl<'a> CodeGenUnit<'a, Equation<'a>> for NumberedEquationGen<'a> {
 
     fn finish(
         self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         let out = gen.get_out();
         writeln!(out, "\\end{{align}}")?;

--- a/src/backend/latex/complex/math.rs
+++ b/src/backend/latex/complex/math.rs
@@ -1,24 +1,26 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::latex::InlineEnvironment;
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::{Equation, Event};
 use crate::generator::Generator;
+use crate::generator::event::{Equation, Event};
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct InlineMathGen;
 
 impl<'a> CodeGenUnit<'a, ()> for InlineMathGen {
     fn new(
-        _cfg: &Config, _tag: (), gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &Config, _tag: (), _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         write!(gen.get_out(), "\\begin{{math}}")?;
         Ok(InlineMathGen)
     }
 
     fn finish(
-        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         write!(gen.get_out(), "\\end{{math}}")?;
         Ok(())
@@ -32,7 +34,7 @@ pub struct EquationGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Equation<'a>> for EquationGen<'a> {
     fn new(
-        _cfg: &Config, eq: Equation<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &Config, eq: Equation<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Equation { label, caption } = eq;
         let inline_fig = InlineEnvironment::new_figure(label, caption);
@@ -45,7 +47,7 @@ impl<'a> CodeGenUnit<'a, Equation<'a>> for EquationGen<'a> {
     }
 
     fn finish(
-        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         write!(out, "\\end{{align*}}")?;
@@ -61,7 +63,7 @@ pub struct NumberedEquationGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Equation<'a>> for NumberedEquationGen<'a> {
     fn new(
-        _cfg: &Config, eq: Equation<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &Config, eq: Equation<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Equation { label, caption } = eq;
         let inline_fig = InlineEnvironment::new_figure(label, caption);
@@ -73,7 +75,7 @@ impl<'a> CodeGenUnit<'a, Equation<'a>> for NumberedEquationGen<'a> {
     }
 
     fn finish(
-        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &'_ mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         writeln!(out, "\\end{{align}}")?;

--- a/src/backend/latex/complex/paragraph.rs
+++ b/src/backend/latex/complex/paragraph.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{Event, Tag};
 use crate::generator::Generator;
 
@@ -12,7 +12,7 @@ pub struct ParagraphGen;
 
 impl<'a> CodeGenUnit<'a, ()> for ParagraphGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(ParagraphGen)
@@ -20,11 +20,11 @@ impl<'a> CodeGenUnit<'a, ()> for ParagraphGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        peek: Option<(&Event<'a>, Range<usize>)>,
+        peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         // TODO: improve latex readability (e.g. no newline between list items)
         // TODO: fix too many linebreaks (e.g. after placeholditimage)
-        match peek.map(|(peek, _)| peek) {
+        match peek.map(|WithRange(peek, _)| peek) {
             Some(Event::Text(_))
             | Some(Event::Html(_))
             | Some(Event::InlineHtml(_))

--- a/src/backend/latex/complex/paragraph.rs
+++ b/src/backend/latex/complex/paragraph.rs
@@ -1,26 +1,28 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::{Event, Tag};
 use crate::generator::Generator;
+use crate::generator::event::{Event, Tag};
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct ParagraphGen;
 
 impl<'a> CodeGenUnit<'a, ()> for ParagraphGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(ParagraphGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         // TODO: improve latex readability (e.g. no newline between list items)
         // TODO: fix too many linebreaks (e.g. after placeholditimage)
-        match peek {
+        match peek.map(|(peek, _)| peek) {
             Some(Event::Text(_))
             | Some(Event::Html(_))
             | Some(Event::InlineHtml(_))

--- a/src/backend/latex/complex/paragraph.rs
+++ b/src/backend/latex/complex/paragraph.rs
@@ -3,22 +3,24 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::{Event, Tag};
 use crate::error::Result;
+use crate::generator::event::{Event, Tag};
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct ParagraphGen;
 
 impl<'a> CodeGenUnit<'a, ()> for ParagraphGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(ParagraphGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         // TODO: improve latex readability (e.g. no newline between list items)
         // TODO: fix too many linebreaks (e.g. after placeholditimage)

--- a/src/backend/latex/complex/rule.rs
+++ b/src/backend/latex/complex/rule.rs
@@ -1,16 +1,18 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::event::Event;
 use crate::generator::{Generator, Stack};
+use crate::generator::event::Event;
+use crate::error::Result;
 
 #[derive(Debug)]
 pub struct RuleGen;
 
 impl<'a> CodeGenUnit<'a, ()> for RuleGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(RuleGen)
     }
@@ -23,7 +25,7 @@ impl<'a> CodeGenUnit<'a, ()> for RuleGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<&Event<'a>>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         // TODO: find out why text after the hrule is indented in the pdf

--- a/src/backend/latex/complex/rule.rs
+++ b/src/backend/latex/complex/rule.rs
@@ -28,7 +28,6 @@ impl<'a> CodeGenUnit<'a, ()> for RuleGen {
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
-        // TODO: find out why text after the hrule is indented in the pdf
         writeln!(out)?;
         writeln!(out, "\\vspace{{1em}}")?;
         writeln!(out, "\\hrule")?;

--- a/src/backend/latex/complex/rule.rs
+++ b/src/backend/latex/complex/rule.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::Event;
 use crate::generator::{Generator, Stack};
 
@@ -12,7 +12,7 @@ pub struct RuleGen;
 
 impl<'a> CodeGenUnit<'a, ()> for RuleGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(RuleGen)
@@ -27,7 +27,7 @@ impl<'a> CodeGenUnit<'a, ()> for RuleGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         let out = gen.get_out();
         writeln!(out)?;

--- a/src/backend/latex/complex/rule.rs
+++ b/src/backend/latex/complex/rule.rs
@@ -3,16 +3,17 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::{Generator, Stack};
-use crate::generator::event::Event;
 use crate::error::Result;
+use crate::generator::event::Event;
+use crate::generator::{Generator, Stack};
 
 #[derive(Debug)]
 pub struct RuleGen;
 
 impl<'a> CodeGenUnit<'a, ()> for RuleGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(RuleGen)
     }
@@ -25,7 +26,8 @@ impl<'a> CodeGenUnit<'a, ()> for RuleGen {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         writeln!(out)?;

--- a/src/backend/latex/complex/table.rs
+++ b/src/backend/latex/complex/table.rs
@@ -6,9 +6,9 @@ use pulldown_cmark::Alignment;
 use crate::backend::latex::InlineEnvironment;
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
-use crate::generator::Generator;
-use crate::generator::event::{Event, Table, Tag};
 use crate::error::Result;
+use crate::generator::event::{Event, Table, Tag};
+use crate::generator::Generator;
 
 #[derive(Debug)]
 pub struct TableGen<'a> {
@@ -17,7 +17,8 @@ pub struct TableGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Table<'a>> for TableGen<'a> {
     fn new(
-        _cfg: &'a Config, table: Table<'a>, _range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, table: Table<'a>, _range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         let Table { label, caption, alignment } = table;
         let inline_table = InlineEnvironment::new_table(label, caption);
@@ -44,7 +45,8 @@ impl<'a> CodeGenUnit<'a, Table<'a>> for TableGen<'a> {
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         let out = gen.get_out();
         writeln!(out, "\\end{{tabularx}}")?;
@@ -58,13 +60,15 @@ pub struct TableHeadGen;
 
 impl<'a> CodeGenUnit<'a, ()> for TableHeadGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(TableHeadGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\\\ \\thickhline")?;
         Ok(())
@@ -76,13 +80,15 @@ pub struct TableRowGen;
 
 impl<'a> CodeGenUnit<'a, ()> for TableRowGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(TableRowGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, _peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\\\ \\hline")?;
         Ok(())
@@ -94,13 +100,15 @@ pub struct TableCellGen;
 
 impl<'a> CodeGenUnit<'a, ()> for TableCellGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>, _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(TableCellGen)
     }
 
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()> {
         if let Event::Start(Tag::TableCell) = peek.unwrap().0 {
             write!(gen.get_out(), "&")?;

--- a/src/backend/latex/complex/table.rs
+++ b/src/backend/latex/complex/table.rs
@@ -1,5 +1,4 @@
 use std::io::Write;
-use std::ops::Range;
 
 use pulldown_cmark::Alignment;
 
@@ -7,6 +6,7 @@ use crate::backend::latex::InlineEnvironment;
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{Event, Table, Tag};
 use crate::generator::Generator;
 
@@ -17,10 +17,10 @@ pub struct TableGen<'a> {
 
 impl<'a> CodeGenUnit<'a, Table<'a>> for TableGen<'a> {
     fn new(
-        _cfg: &'a Config, table: Table<'a>, _range: Range<usize>,
+        _cfg: &'a Config, table: WithRange<Table<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let Table { label, caption, alignment } = table;
+        let WithRange(Table { label, caption, alignment }, _range) = table;
         let inline_table = InlineEnvironment::new_table(label, caption);
         let out = gen.get_out();
         inline_table.write_begin(&mut *out)?;
@@ -46,7 +46,7 @@ impl<'a> CodeGenUnit<'a, Table<'a>> for TableGen<'a> {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         let out = gen.get_out();
         writeln!(out, "\\end{{tabularx}}")?;
@@ -60,7 +60,7 @@ pub struct TableHeadGen;
 
 impl<'a> CodeGenUnit<'a, ()> for TableHeadGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(TableHeadGen)
@@ -68,7 +68,7 @@ impl<'a> CodeGenUnit<'a, ()> for TableHeadGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\\\ \\thickhline")?;
         Ok(())
@@ -80,7 +80,7 @@ pub struct TableRowGen;
 
 impl<'a> CodeGenUnit<'a, ()> for TableRowGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(TableRowGen)
@@ -88,7 +88,7 @@ impl<'a> CodeGenUnit<'a, ()> for TableRowGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        _peek: Option<(&Event<'a>, Range<usize>)>,
+        _peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         writeln!(gen.get_out(), "\\\\ \\hline")?;
         Ok(())
@@ -100,7 +100,7 @@ pub struct TableCellGen;
 
 impl<'a> CodeGenUnit<'a, ()> for TableCellGen {
     fn new(
-        _cfg: &'a Config, _tag: (), _range: Range<usize>,
+        _cfg: &'a Config, _: WithRange<()>,
         _gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
         Ok(TableCellGen)
@@ -108,7 +108,7 @@ impl<'a> CodeGenUnit<'a, ()> for TableCellGen {
 
     fn finish(
         self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
-        peek: Option<(&Event<'a>, Range<usize>)>,
+        peek: Option<WithRange<&Event<'a>>>,
     ) -> Result<()> {
         if let Event::Start(Tag::TableCell) = peek.unwrap().0 {
             write!(gen.get_out(), "&")?;

--- a/src/backend/latex/document/article.rs
+++ b/src/backend/latex/document/article.rs
@@ -1,4 +1,7 @@
 use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+use codespan_reporting::termcolor::StandardStream;
 
 use crate::backend::latex::{self, preamble};
 use crate::backend::Backend;
@@ -63,7 +66,7 @@ impl<'a> Backend<'a> for Article {
         Article
     }
 
-    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
+    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write, _stderr: Arc<Mutex<StandardStream>>) -> FatalResult<()> {
         // TODO: itemizespacing
         // documentclass
         write!(out, "\\documentclass[")?;
@@ -124,7 +127,7 @@ impl<'a> Backend<'a> for Article {
         Ok(())
     }
 
-    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
+    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write, _stderr: Arc<Mutex<StandardStream>>) -> FatalResult<()> {
         writeln!(out, "\\end{{document}}")?;
         Ok(())
     }

--- a/src/backend/latex/document/article.rs
+++ b/src/backend/latex/document/article.rs
@@ -1,8 +1,9 @@
-use std::io::{Result, Write};
+use std::io::Write;
 
 use crate::backend::latex::{self, preamble};
 use crate::backend::Backend;
 use crate::config::Config;
+use crate::error::FatalResult;
 
 #[derive(Debug)]
 pub struct Article;
@@ -62,7 +63,7 @@ impl<'a> Backend<'a> for Article {
         Article
     }
 
-    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> Result<()> {
+    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
         // TODO: itemizespacing
         // documentclass
         write!(out, "\\documentclass[")?;
@@ -123,7 +124,7 @@ impl<'a> Backend<'a> for Article {
         Ok(())
     }
 
-    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> Result<()> {
+    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
         writeln!(out, "\\end{{document}}")?;
         Ok(())
     }

--- a/src/backend/latex/document/report.rs
+++ b/src/backend/latex/document/report.rs
@@ -1,8 +1,9 @@
-use std::io::{Result, Write};
+use std::io::Write;
 
 use crate::backend::latex::{self, preamble};
 use crate::backend::Backend;
 use crate::config::Config;
+use crate::error::FatalResult;
 
 #[derive(Debug)]
 pub struct Report;
@@ -62,7 +63,7 @@ impl<'a> Backend<'a> for Report {
         Report
     }
 
-    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> Result<()> {
+    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
         // TODO: itemizespacing
         // documentclass
         write!(out, "\\documentclass[")?;
@@ -124,7 +125,7 @@ impl<'a> Backend<'a> for Report {
         Ok(())
     }
 
-    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> Result<()> {
+    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
         writeln!(out, "\\end{{document}}")?;
         Ok(())
     }

--- a/src/backend/latex/document/report.rs
+++ b/src/backend/latex/document/report.rs
@@ -1,4 +1,7 @@
 use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+use codespan_reporting::termcolor::StandardStream;
 
 use crate::backend::latex::{self, preamble};
 use crate::backend::Backend;
@@ -63,7 +66,7 @@ impl<'a> Backend<'a> for Report {
         Report
     }
 
-    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
+    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write, _stderr: Arc<Mutex<StandardStream>>) -> FatalResult<()> {
         // TODO: itemizespacing
         // documentclass
         write!(out, "\\documentclass[")?;
@@ -125,7 +128,7 @@ impl<'a> Backend<'a> for Report {
         Ok(())
     }
 
-    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
+    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write, _stderr: Arc<Mutex<StandardStream>>) -> FatalResult<()> {
         writeln!(out, "\\end{{document}}")?;
         Ok(())
     }

--- a/src/backend/latex/document/thesis.rs
+++ b/src/backend/latex/document/thesis.rs
@@ -9,6 +9,7 @@ use crate::backend::Backend;
 use crate::config::Config;
 use crate::generator::Generator;
 use crate::resolve::Context;
+use crate::diagnostics::Input;
 
 #[derive(Debug)]
 pub struct Thesis;
@@ -133,7 +134,9 @@ fn gen(path: PathBuf, cfg: &Config, out: &mut impl Write) -> Result<()> {
     let arena = Arena::new();
     let mut gen = Generator::new(cfg, Thesis, out, &arena);
     let markdown = fs::read_to_string(&path)?;
-    let events = gen.get_events(markdown, Context::LocalRelative(path));
+    let context = Context::LocalRelative(path.clone());
+    let input = Input::File(path);
+    let events = gen.get_events(markdown, context, input);
     gen.generate_body(events)?;
     Ok(())
 }

--- a/src/backend/latex/document/thesis.rs
+++ b/src/backend/latex/document/thesis.rs
@@ -7,10 +7,10 @@ use typed_arena::Arena;
 use crate::backend::latex::{self, preamble};
 use crate::backend::Backend;
 use crate::config::Config;
+use crate::diagnostics::Input;
 use crate::error::FatalResult;
 use crate::generator::Generator;
 use crate::resolve::Context;
-use crate::diagnostics::Input;
 
 #[derive(Debug)]
 pub struct Thesis;

--- a/src/backend/latex/document/thesis.rs
+++ b/src/backend/latex/document/thesis.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{Result, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use typed_arena::Arena;
@@ -7,6 +7,7 @@ use typed_arena::Arena;
 use crate::backend::latex::{self, preamble};
 use crate::backend::Backend;
 use crate::config::Config;
+use crate::error::FatalResult;
 use crate::generator::Generator;
 use crate::resolve::Context;
 use crate::diagnostics::Input;
@@ -69,7 +70,7 @@ impl<'a> Backend<'a> for Thesis {
         Thesis
     }
 
-    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> Result<()> {
+    fn gen_preamble(&mut self, cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
         // TODO: itemizespacing
         // documentclass
         write!(out, "\\documentclass[")?;
@@ -124,13 +125,13 @@ impl<'a> Backend<'a> for Thesis {
         Ok(())
     }
 
-    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> Result<()> {
+    fn gen_epilogue(&mut self, _cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
         writeln!(out, "\\end{{document}}")?;
         Ok(())
     }
 }
 
-fn gen(path: PathBuf, cfg: &Config, out: &mut impl Write) -> Result<()> {
+fn gen(path: PathBuf, cfg: &Config, out: &mut impl Write) -> FatalResult<()> {
     let arena = Arena::new();
     let mut gen = Generator::new(cfg, Thesis, out, &arena);
     let markdown = fs::read_to_string(&path)?;

--- a/src/backend/latex/mod.rs
+++ b/src/backend/latex/mod.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::io::{Result, Write};
+use std::ops::Range;
 
 mod complex;
 mod document;
@@ -70,20 +71,20 @@ use self::complex::{
 /// Thus we create an inline figure / table with placement specifier `H` (from the `float` package).
 #[derive(Debug)]
 struct InlineEnvironment<'a> {
-    pub label: Option<Cow<'a, str>>,
-    pub caption: Option<Cow<'a, str>>,
+    pub label: Option<(Cow<'a, str>, Range<usize>)>,
+    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
     environment: &'static str,
 }
 
 impl<'a> InlineEnvironment<'a> {
     pub fn new_figure(
-        label: Option<Cow<'a, str>>, caption: Option<Cow<'a, str>>,
+        label: Option<(Cow<'a, str>, Range<usize>)>, caption: Option<(Cow<'a, str>, Range<usize>)>,
     ) -> InlineEnvironment<'a> {
         InlineEnvironment { label, caption, environment: "figure" }
     }
 
     pub fn new_table(
-        label: Option<Cow<'a, str>>, caption: Option<Cow<'a, str>>,
+        label: Option<(Cow<'a, str>, Range<usize>)>, caption: Option<(Cow<'a, str>, Range<usize>)>,
     ) -> InlineEnvironment<'a> {
         InlineEnvironment { label, caption, environment: "table" }
     }
@@ -100,7 +101,7 @@ impl<'a> InlineEnvironment<'a> {
             return Ok(());
         }
 
-        if let Some(caption) = &self.caption {
+        if let Some((caption, _)) = &self.caption {
             if self.label.is_some() {
                 writeln!(out, "\\caption{{{}}}", caption)?;
             } else {
@@ -110,7 +111,7 @@ impl<'a> InlineEnvironment<'a> {
             writeln!(out, "\\caption{{}}")?;
         }
 
-        if let Some(label) = &self.label {
+        if let Some((label, _)) = &self.label {
             writeln!(out, "\\label{{{}}}", label)?;
         }
 

--- a/src/backend/latex/mod.rs
+++ b/src/backend/latex/mod.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::io::{Result, Write};
-use std::ops::Range;
 
 mod complex;
 mod document;
@@ -10,6 +9,8 @@ mod replace;
 mod simple;
 
 pub use self::document::{Article, Report, Thesis};
+
+use crate::frontend::range::WithRange;
 
 use self::simple::{
     AppendixGen,
@@ -71,20 +72,20 @@ use self::complex::{
 /// Thus we create an inline figure / table with placement specifier `H` (from the `float` package).
 #[derive(Debug)]
 struct InlineEnvironment<'a> {
-    pub label: Option<(Cow<'a, str>, Range<usize>)>,
-    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
+    pub label: Option<WithRange<Cow<'a, str>>>,
+    pub caption: Option<WithRange<Cow<'a, str>>>,
     environment: &'static str,
 }
 
 impl<'a> InlineEnvironment<'a> {
     pub fn new_figure(
-        label: Option<(Cow<'a, str>, Range<usize>)>, caption: Option<(Cow<'a, str>, Range<usize>)>,
+        label: Option<WithRange<Cow<'a, str>>>, caption: Option<WithRange<Cow<'a, str>>>,
     ) -> InlineEnvironment<'a> {
         InlineEnvironment { label, caption, environment: "figure" }
     }
 
     pub fn new_table(
-        label: Option<(Cow<'a, str>, Range<usize>)>, caption: Option<(Cow<'a, str>, Range<usize>)>,
+        label: Option<WithRange<Cow<'a, str>>>, caption: Option<WithRange<Cow<'a, str>>>,
     ) -> InlineEnvironment<'a> {
         InlineEnvironment { label, caption, environment: "table" }
     }
@@ -101,7 +102,7 @@ impl<'a> InlineEnvironment<'a> {
             return Ok(());
         }
 
-        if let Some((caption, _)) = &self.caption {
+        if let Some(WithRange(caption, _)) = &self.caption {
             if self.label.is_some() {
                 writeln!(out, "\\caption{{{}}}", caption)?;
             } else {
@@ -111,7 +112,7 @@ impl<'a> InlineEnvironment<'a> {
             writeln!(out, "\\caption{{}}")?;
         }
 
-        if let Some((label, _)) = &self.label {
+        if let Some(WithRange(label, _)) = &self.label {
             writeln!(out, "\\label{{{}}}", label)?;
         }
 

--- a/src/backend/latex/simple.rs
+++ b/src/backend/latex/simple.rs
@@ -22,15 +22,13 @@ pub struct TextGen;
 
 impl<'a> MediumCodeGenUnit<Cow<'a, str>> for TextGen {
     fn gen<'b, 'c>(
-        text: Cow<'a, str>, _range: Range<usize>, stack: &mut Stack<'b, 'c, impl Backend<'b>, impl Write>,
+        text: Cow<'a, str>, _range: Range<usize>,
+        stack: &mut Stack<'b, 'c, impl Backend<'b>, impl Write>,
     ) -> Result<()> {
         // TODO: make code-blocks containing unicode allow inline-math
         // handle unicode
-        let strfn: fn(&str) -> &str = if stack.iter().any(|e| e.is_math()) {
-            |s| &s[1..s.len() - 1]
-        } else {
-            |s| s
-        };
+        let strfn: fn(&str) -> &str =
+            if stack.iter().any(|e| e.is_math()) { |s| &s[1..s.len() - 1] } else { |s| s };
 
         let in_inline_code = stack.iter().any(|e| e.is_inline_code());
         let in_code_or_math = stack.iter().any(|e| e.is_code() || e.is_math());
@@ -92,7 +90,9 @@ impl<'a> SimpleCodeGenUnit<FootnoteReference<'a>> for FootnoteReferenceGen {
 pub struct BiberReferencesGen;
 
 impl<'a> SimpleCodeGenUnit<Vec<BiberReference<'a>>> for BiberReferencesGen {
-    fn gen(mut biber: Vec<BiberReference<'a>>, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
+    fn gen(
+        mut biber: Vec<BiberReference<'a>>, _range: Range<usize>, out: &mut impl Write,
+    ) -> Result<()> {
         if biber.len() == 1 {
             let BiberReference { reference, attributes } = biber.pop().unwrap();
             match attributes {
@@ -221,7 +221,9 @@ impl SimpleCodeGenUnit<()> for SoftBreakGen {
 pub struct HardBreakGen;
 
 impl MediumCodeGenUnit<()> for HardBreakGen {
-    fn gen<'b, 'c>((): (), _range: Range<usize>, stack: &mut Stack<'b, 'c, impl Backend<'b>, impl Write>) -> Result<()> {
+    fn gen<'b, 'c>(
+        (): (), _range: Range<usize>, stack: &mut Stack<'b, 'c, impl Backend<'b>, impl Write>,
+    ) -> Result<()> {
         let in_table = stack.iter().any(|e| e.is_table());
         let out = stack.get_out();
 

--- a/src/backend/latex/simple.rs
+++ b/src/backend/latex/simple.rs
@@ -1,9 +1,11 @@
 use std::borrow::Cow;
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use super::replace::replace;
 use crate::backend::latex::InlineEnvironment;
 use crate::backend::{Backend, MediumCodeGenUnit, SimpleCodeGenUnit};
+use crate::error::Result;
 use crate::generator::event::{
     BiberReference,
     FootnoteReference,
@@ -20,7 +22,7 @@ pub struct TextGen;
 
 impl<'a> MediumCodeGenUnit<Cow<'a, str>> for TextGen {
     fn gen<'b, 'c>(
-        text: Cow<'a, str>, stack: &mut Stack<'b, 'c, impl Backend<'b>, impl Write>,
+        text: Cow<'a, str>, _range: Range<usize>, stack: &mut Stack<'b, 'c, impl Backend<'b>, impl Write>,
     ) -> Result<()> {
         // TODO: make code-blocks containing unicode allow inline-math
         // handle unicode
@@ -75,7 +77,7 @@ impl<'a> MediumCodeGenUnit<Cow<'a, str>> for TextGen {
 pub struct LatexGen;
 
 impl<'a> SimpleCodeGenUnit<Cow<'a, str>> for LatexGen {
-    fn gen(latex: Cow<'a, str>, out: &mut impl Write) -> Result<()> {
+    fn gen(latex: Cow<'a, str>, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         write!(out, "{}", latex)?;
         Ok(())
     }
@@ -85,7 +87,7 @@ impl<'a> SimpleCodeGenUnit<Cow<'a, str>> for LatexGen {
 pub struct FootnoteReferenceGen;
 
 impl<'a> SimpleCodeGenUnit<FootnoteReference<'a>> for FootnoteReferenceGen {
-    fn gen(fnote: FootnoteReference<'a>, out: &mut impl Write) -> Result<()> {
+    fn gen(fnote: FootnoteReference<'a>, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         let FootnoteReference { label } = fnote;
         write!(out, "\\footnotemark[\\getrefnumber{{fnote:{}}}]", label)?;
         Ok(())
@@ -96,7 +98,7 @@ impl<'a> SimpleCodeGenUnit<FootnoteReference<'a>> for FootnoteReferenceGen {
 pub struct BiberReferencesGen;
 
 impl<'a> SimpleCodeGenUnit<Vec<BiberReference<'a>>> for BiberReferencesGen {
-    fn gen(mut biber: Vec<BiberReference<'a>>, out: &mut impl Write) -> Result<()> {
+    fn gen(mut biber: Vec<BiberReference<'a>>, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         if biber.len() == 1 {
             let BiberReference { reference, attributes } = biber.pop().unwrap();
             match attributes {
@@ -120,7 +122,7 @@ impl<'a> SimpleCodeGenUnit<Vec<BiberReference<'a>>> for BiberReferencesGen {
 pub struct UrlGen;
 
 impl<'a> SimpleCodeGenUnit<Url<'a>> for UrlGen {
-    fn gen(url: Url<'a>, out: &mut impl Write) -> Result<()> {
+    fn gen(url: Url<'a>, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         let Url { destination, title } = url;
         match title {
             None => write!(out, "\\url{{{}}}", destination)?,
@@ -134,7 +136,7 @@ impl<'a> SimpleCodeGenUnit<Url<'a>> for UrlGen {
 pub struct InterLinkGen;
 
 impl<'a> SimpleCodeGenUnit<InterLink<'a>> for InterLinkGen {
-    fn gen(interlink: InterLink<'a>, out: &mut impl Write) -> Result<()> {
+    fn gen(interlink: InterLink<'a>, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         let InterLink { label, uppercase } = interlink;
         match uppercase {
             true => write!(out, "\\Cref{{{}}}", label)?,
@@ -148,7 +150,7 @@ impl<'a> SimpleCodeGenUnit<InterLink<'a>> for InterLinkGen {
 pub struct ImageGen;
 
 impl<'a> SimpleCodeGenUnit<Image<'a>> for ImageGen {
-    fn gen(image: Image<'a>, out: &mut impl Write) -> Result<()> {
+    fn gen(image: Image<'a>, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         let Image { label, caption, title, alt_text, path, scale, width, height } = image;
         let inline_fig = InlineEnvironment::new_figure(label, caption);
         inline_fig.write_begin(&mut *out)?;
@@ -191,8 +193,9 @@ impl<'a> SimpleCodeGenUnit<Image<'a>> for ImageGen {
 pub struct LabelGen;
 
 impl<'a> SimpleCodeGenUnit<Cow<'a, str>> for LabelGen {
-    fn gen(label: Cow<'a, str>, out: &mut impl Write) -> Result<()> {
-        writeln!(out, "\\label{{{}}}", label)
+    fn gen(label: Cow<'a, str>, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
+        writeln!(out, "\\label{{{}}}", label)?;
+        Ok(())
     }
 }
 
@@ -200,7 +203,7 @@ impl<'a> SimpleCodeGenUnit<Cow<'a, str>> for LabelGen {
 pub struct PdfGen;
 
 impl SimpleCodeGenUnit<Pdf> for PdfGen {
-    fn gen(pdf: Pdf, out: &mut impl Write) -> Result<()> {
+    fn gen(pdf: Pdf, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         let Pdf { path } = pdf;
 
         writeln!(out, "\\includepdf[pages=-]{{{}}}", path.display())?;
@@ -212,7 +215,7 @@ impl SimpleCodeGenUnit<Pdf> for PdfGen {
 pub struct SoftBreakGen;
 
 impl SimpleCodeGenUnit<()> for SoftBreakGen {
-    fn gen((): (), out: &mut impl Write) -> Result<()> {
+    fn gen((): (), _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         // soft breaks are only used to split up text in lines in the source file
         // so it's nothing we should translate, but for better readability keep them
         writeln!(out)?;
@@ -224,7 +227,7 @@ impl SimpleCodeGenUnit<()> for SoftBreakGen {
 pub struct HardBreakGen;
 
 impl MediumCodeGenUnit<()> for HardBreakGen {
-    fn gen<'b, 'c>((): (), stack: &mut Stack<'b, 'c, impl Backend<'b>, impl Write>) -> Result<()> {
+    fn gen<'b, 'c>((): (), _range: Range<usize>, stack: &mut Stack<'b, 'c, impl Backend<'b>, impl Write>) -> Result<()> {
         let in_table = stack.iter().any(|e| e.is_table());
         let out = stack.get_out();
 
@@ -242,7 +245,7 @@ impl MediumCodeGenUnit<()> for HardBreakGen {
 pub struct TaskListMarkerGen;
 
 impl SimpleCodeGenUnit<TaskListMarker> for TaskListMarkerGen {
-    fn gen(marker: TaskListMarker, out: &mut impl Write) -> Result<()> {
+    fn gen(marker: TaskListMarker, _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         let TaskListMarker { checked } = marker;
         match checked {
             true => write!(out, r"[$\boxtimes$] ")?,
@@ -256,7 +259,7 @@ impl SimpleCodeGenUnit<TaskListMarker> for TaskListMarkerGen {
 pub struct TableOfContentsGen;
 
 impl SimpleCodeGenUnit<()> for TableOfContentsGen {
-    fn gen((): (), out: &mut impl Write) -> Result<()> {
+    fn gen((): (), _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         writeln!(out, "\\tableofcontents")?;
         Ok(())
     }
@@ -266,7 +269,7 @@ impl SimpleCodeGenUnit<()> for TableOfContentsGen {
 pub struct BibliographyGen;
 
 impl SimpleCodeGenUnit<()> for BibliographyGen {
-    fn gen((): (), out: &mut impl Write) -> Result<()> {
+    fn gen((): (), _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         // TODO: config option if bibliography in toc
         // TODO: config option for title
         writeln!(out, "\\printbibliography[heading=bibintoc]")?;
@@ -278,7 +281,7 @@ impl SimpleCodeGenUnit<()> for BibliographyGen {
 pub struct ListOfTablesGen;
 
 impl SimpleCodeGenUnit<()> for ListOfTablesGen {
-    fn gen((): (), out: &mut impl Write) -> Result<()> {
+    fn gen((): (), _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         writeln!(out, "\\microtypesetup{{protrusion=false}}")?;
         writeln!(out, "\\listoftables")?;
         writeln!(out, "\\microtypesetup{{protrusion=true}}")?;
@@ -290,7 +293,7 @@ impl SimpleCodeGenUnit<()> for ListOfTablesGen {
 pub struct ListOfFiguresGen;
 
 impl SimpleCodeGenUnit<()> for ListOfFiguresGen {
-    fn gen((): (), out: &mut impl Write) -> Result<()> {
+    fn gen((): (), _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         writeln!(out, "\\microtypesetup{{protrusion=false}}")?;
         writeln!(out, "\\listoffigures")?;
         writeln!(out, "\\microtypesetup{{protrusion=true}}")?;
@@ -302,7 +305,7 @@ impl SimpleCodeGenUnit<()> for ListOfFiguresGen {
 pub struct ListOfListingsGen;
 
 impl SimpleCodeGenUnit<()> for ListOfListingsGen {
-    fn gen((): (), out: &mut impl Write) -> Result<()> {
+    fn gen((): (), _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         writeln!(out, "\\microtypesetup{{protrusion=false}}")?;
         writeln!(out, "\\lstlistoflistings")?;
         writeln!(out, "\\microtypesetup{{protrusion=true}}")?;
@@ -314,7 +317,7 @@ impl SimpleCodeGenUnit<()> for ListOfListingsGen {
 pub struct AppendixGen;
 
 impl SimpleCodeGenUnit<()> for AppendixGen {
-    fn gen((): (), out: &mut impl Write) -> Result<()> {
+    fn gen((): (), _range: Range<usize>, out: &mut impl Write) -> Result<()> {
         writeln!(out, "\\appendix{{}}")?;
         writeln!(out, "\\renewcommand\\thelstlisting{{\\Alph{{lstlisting}}}}")?;
         writeln!(out, "\\setcounter{{lstlisting}}{{0}}")?;

--- a/src/backend/latex/simple.rs
+++ b/src/backend/latex/simple.rs
@@ -158,13 +158,13 @@ impl<'a> SimpleCodeGenUnit<Image<'a>> for ImageGen {
             write!(out, "\\includegraphics[")?;
         }
 
-        if let Some(scale) = scale {
+        if let Some((scale, _)) = scale {
             write!(out, "scale={}", scale)?;
         }
-        if let Some(width) = width {
+        if let Some((width, _)) = width {
             write!(out, "width={},", width)?;
         }
-        if let Some(height) = height {
+        if let Some((height, _)) = height {
             write!(out, "height={},", height)?;
         }
 

--- a/src/backend/latex/simple.rs
+++ b/src/backend/latex/simple.rs
@@ -26,16 +26,10 @@ impl<'a> MediumCodeGenUnit<Cow<'a, str>> for TextGen {
     ) -> Result<()> {
         // TODO: make code-blocks containing unicode allow inline-math
         // handle unicode
-        let strfn = if stack.iter().any(|e| e.is_math()) {
-            fn a(s: &str) -> &str {
-                &s[1..s.len() - 1]
-            }
-            a
+        let strfn: fn(&str) -> &str = if stack.iter().any(|e| e.is_math()) {
+            |s| &s[1..s.len() - 1]
         } else {
-            fn a(s: &str) -> &str {
-                s
-            }
-            a
+            |s| s
         };
 
         let in_inline_code = stack.iter().any(|e| e.is_inline_code());

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,6 +5,8 @@ use std::ops::Range;
 
 use typed_arena::Arena;
 
+use crate::config::Config;
+use crate::error::{FatalResult, Result};
 use crate::generator::event::{
     BiberReference,
     CodeBlock,
@@ -24,8 +26,6 @@ use crate::generator::event::{
     Url,
 };
 use crate::generator::{Generator, Stack};
-use crate::config::Config;
-use crate::error::{Result, FatalResult};
 
 pub mod latex;
 
@@ -96,7 +96,8 @@ pub trait Backend<'a>: Debug {
 
 pub trait CodeGenUnit<'a, T>: Sized + Debug {
     fn new(
-        cfg: &'a Config, tag: T, range: Range<usize>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        cfg: &'a Config, tag: T, range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self>;
     fn output_redirect(&mut self) -> Option<&mut dyn Write> {
         None
@@ -107,7 +108,8 @@ pub trait CodeGenUnit<'a, T>: Sized + Debug {
         Ok(Some(e))
     }
     fn finish(
-        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, peek: Option<(&Event<'a>, Range<usize>)>,
+        self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+        peek: Option<(&Event<'a>, Range<usize>)>,
     ) -> Result<()>;
 }
 
@@ -116,11 +118,15 @@ pub trait SimpleCodeGenUnit<T> {
 }
 
 pub trait MediumCodeGenUnit<T> {
-    fn gen<'a, 'b>(data: T, range: Range<usize>, stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>) -> Result<()>;
+    fn gen<'a, 'b>(
+        data: T, range: Range<usize>, stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>,
+    ) -> Result<()>;
 }
 
 impl<T: SimpleCodeGenUnit<D>, D> MediumCodeGenUnit<D> for T {
-    fn gen<'a, 'b>(data: D, range: Range<usize>, stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>) -> Result<()> {
+    fn gen<'a, 'b>(
+        data: D, range: Range<usize>, stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>,
+    ) -> Result<()> {
         T::gen(data, range, &mut stack.get_out())
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -25,7 +25,7 @@ use crate::generator::event::{
 };
 use crate::generator::{Generator, Stack};
 use crate::config::Config;
-use crate::error::{Result};
+use crate::error::Result;
 
 pub mod latex;
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use typed_arena::Arena;
 
@@ -23,10 +24,10 @@ use crate::generator::event::{
     Url,
 };
 use crate::generator::{Generator, Stack};
+use crate::config::Config;
+use crate::error::{Result};
 
 pub mod latex;
-
-use crate::config::Config;
 
 pub fn generate<'a>(
     cfg: &'a Config, doc: impl Backend<'a>, arena: &'a Arena<String>, markdown: String,
@@ -111,15 +112,15 @@ pub trait CodeGenUnit<'a, T>: Sized + Debug {
 }
 
 pub trait SimpleCodeGenUnit<T> {
-    fn gen(data: T, out: &mut impl Write) -> Result<()>;
+    fn gen(data: T, range: Range<usize>, out: &mut impl Write) -> Result<()>;
 }
 
 pub trait MediumCodeGenUnit<T> {
-    fn gen<'a, 'b>(data: T, stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>) -> Result<()>;
+    fn gen<'a, 'b>(data: T, range: Range<usize>, stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>) -> Result<()>;
 }
 
 impl<T: SimpleCodeGenUnit<D>, D> MediumCodeGenUnit<D> for T {
-    fn gen<'a, 'b>(data: D, stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>) -> Result<()> {
-        T::gen(data, &mut stack.get_out())
+    fn gen<'a, 'b>(data: D, range: Range<usize>, stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>) -> Result<()> {
+        T::gen(data, range, &mut stack.get_out())
     }
 }

--- a/src/cskvp.rs
+++ b/src/cskvp.rs
@@ -9,15 +9,17 @@ use single::{self, Single};
 use crate::ext::{CowExt, VecExt};
 use crate::diagnostics::Diagnostics;
 
+struct Diagnostic;
+
 #[derive(Debug)]
 pub struct Cskvp<'a> {
     diagnostics: Option<Diagnostics<'a>>,
     range: Range<usize>,
-    label: Option<Cow<'a, str>>,
-    caption: Option<Cow<'a, str>>,
-    figure: Option<bool>,
-    single: Vec<Cow<'a, str>>,
-    double: HashMap<Cow<'a, str>, Cow<'a, str>>,
+    label: Option<(Cow<'a, str>, Range<usize>)>,
+    caption: Option<(Cow<'a, str>, Range<usize>)>,
+    figure: Option<(bool, Range<usize>)>,
+    single: Vec<(Cow<'a, str>, Range<usize>)>,
+    double: HashMap<Cow<'a, str>, (Cow<'a, str>, Range<usize>)>,
 }
 
 impl<'a> Default for Cskvp<'a> {
@@ -35,56 +37,63 @@ impl<'a> Default for Cskvp<'a> {
 }
 
 impl<'a> Cskvp<'a> {
-    pub fn new(s: Cow<'a, str>, range: Range<usize>, diagnostics: Diagnostics<'a>) -> Cskvp<'a> {
-        let parser = Parser::new(s);
+    pub fn new(s: Cow<'a, str>, range: Range<usize>, content_range: Range<usize>, mut diagnostics: Diagnostics<'a>) -> Cskvp<'a> {
+        let mut parser = Parser::new(s, content_range);
 
         let mut single = Vec::new();
         let mut double = HashMap::new();
-        let mut label = None;
-        for value in parser {
+        let mut label: Option<(_, Range<usize>)> = None;
+        while let Ok(Some((value, range))) = parser.next(&mut diagnostics) {
             match value {
                 Value::Double(key, value) => {
-                    double.insert(key, value);
+                    double.insert(key, (value, range));
                 },
                 Value::Single(mut value) => {
                     if value.starts_with('#') {
                         if label.is_some() {
-                            // TODO: warn
-                            println!(
-                                "Found two labels, taking the last: {} and {}",
-                                label.as_ref().unwrap(),
-                                &value[1..]
-                            );
+                            diagnostics
+                                .warning("found two labels")
+                                .with_info_section(&label.as_ref().unwrap().1, "first label defined here")
+                                .with_info_section(&range, "second label defined here")
+                                .note("using the last")
+                                .emit();
                         }
                         value.truncate_start(1);
-                        label = Some(value);
+                        label = Some((value, range));
                     } else {
-                        single.push(value);
+                        single.push((value, range));
                     }
                 },
             }
         }
 
-        let figure_double = double.remove("figure").and_then(|s| match s.parse() {
-            Ok(val) => Some(val),
+        let figure_double = double.remove("figure").and_then(|(s, range)| match s.parse() {
+            Ok(val) => Some((val, range)),
             Err(_) => {
-                // TODO: warn
-                println!("cannot parse `figure={}`, only `true` and `false` are allowed", s);
+                diagnostics
+                    .error("cannot parse figure value")
+                    .with_error_section(&range, "defined here")
+                    .note("only `true` and `false` are allowed")
+                    .emit();
                 None
             },
         });
-        let figure = single.remove_element(&"figure").map(|_| true);
-        let nofigure = single.remove_element(&"nofigure").map(|_| false);
+        let figure = single.remove_element(&"figure").map(|(_, range)| (true, range));
+        let nofigure = single.remove_element(&"nofigure").map(|(_, range)| (false, range));
 
-        let figure = match [figure_double, figure, nofigure].iter().cloned().flatten().single() {
+        let figures = [figure_double, figure, nofigure];
+        let figure = match figures.iter().cloned().flatten().single() {
             Ok(val) => Some(val),
             Err(single::Error::NoElements) => None,
             Err(single::Error::MultipleElements) => {
-                // TODO: warn
-                println!(
-                    "only one of `figure=true`, `figure=false`, `figure` and `nofigure` allowed, \
-                     found multiple"
-                );
+                let mut diag = Some(diagnostics
+                    .error("found multiple figure specifiers"));
+                for (_, range) in figures.iter().cloned().flatten() {
+                    diag = Some(diag.take().unwrap().with_info_section(&range, "one defined here"));
+                }
+                diag.unwrap()
+                    .note("only one of `figure=true`, `figure=false`, `figure` and `nofigure` is allowed")
+                    .emit();
                 None
             },
         };
@@ -108,19 +117,19 @@ impl<'a> Cskvp<'a> {
         self.label.is_some()
     }
 
-    pub fn take_label(&mut self) -> Option<Cow<'a, str>> {
+    pub fn take_label(&mut self) -> Option<(Cow<'a, str>, Range<usize>)> {
         self.label.take()
     }
 
-    pub fn take_figure(&mut self) -> Option<bool> {
+    pub fn take_figure(&mut self) -> Option<(bool, Range<usize>)> {
         self.figure.take()
     }
 
-    pub fn take_caption(&mut self) -> Option<Cow<'a, str>> {
+    pub fn take_caption(&mut self) -> Option<(Cow<'a, str>, Range<usize>)> {
         self.caption.take()
     }
 
-    pub fn take_double(&mut self, key: &str) -> Option<Cow<'a, str>> {
+    pub fn take_double(&mut self, key: &str) -> Option<(Cow<'a, str>, Range<usize>)> {
         self.double.remove(key)
     }
 
@@ -144,27 +153,41 @@ impl<'a> Drop for Cskvp<'a> {
             .as_mut()
             .map(|d| d
                 .warning("in element config")
-                .with_section(range, "")
+                .with_error_section(range, "")
             );
-        // TODO: warn
-        if let Some(label) = self.label.as_ref() {
-            diag = diag.map(|d| d.warning(format!("label ignored: {}", label)));
+        if let Some((label, range)) = self.label.as_ref() {
+            diag = diag.map(|d| {
+                d.warning(format!("label ignored: {}", label))
+                    .with_info_section(range, "label defined here")
+            });
             has_warning = true;
         }
-        if let Some(figure) = self.figure {
-            diag = diag.map(|d| d.warning(format!("figure config ignored: {}", figure)));
+        if let Some((figure, range)) = self.figure.as_ref() {
+            diag = diag.map(|d| {
+                d.warning(format!("figure config ignored: {}", figure))
+                    .with_info_section(range, "figure config defined here")
+            });
             has_warning = true;
         }
-        if let Some(caption) = self.caption.as_ref() {
-            diag = diag.map(|d| d.warning(format!("caption ignored: {}", caption)));
+        if let Some((caption, range)) = self.caption.as_ref() {
+            diag = diag.map(|d| {
+                d.warning(format!("caption ignored: {}", caption))
+                    .with_info_section(range, "caption defined here")
+            });
             has_warning = true;
         }
-        for (k, v) in self.double.drain() {
-            diag = diag.map(|d| d.warning(format!("unknown attribute `{}={}`", k, v)));
+        for (k, (v, range)) in self.double.drain() {
+            diag = diag.map(|d| {
+                d.warning(format!("unknown attribute `{}={}`", k, v))
+                    .with_info_section(&range, "attribute defined here")
+            });
             has_warning = true;
         }
-        for attr in self.single.drain(..) {
-            diag = diag.map(|d| d.warning(format!("unknown attribute `{}`", attr)));
+        for (attr, range) in self.single.drain(..) {
+            diag = diag.map(|d| {
+                d.warning(format!("unknown attribute `{}`", attr))
+                    .with_info_section(&range, "attribute defined here")
+            });
             has_warning = true;
         }
 
@@ -178,6 +201,7 @@ impl<'a> Drop for Cskvp<'a> {
 
 struct Parser<'a> {
     rest: Cow<'a, str>,
+    range: Range<usize>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -187,37 +211,74 @@ enum Value<'a> {
 }
 
 impl<'a> Parser<'a> {
-    fn new(s: Cow<'a, str>) -> Parser<'a> {
-        Parser { rest: s }
+    fn new(s: Cow<'a, str>, range: Range<usize>) -> Parser<'a> {
+        Parser { rest: s, range }
     }
 
-    fn next_quoted(&mut self) -> Cow<'a, str> {
-        assert!(self.rest.trim_start().starts_with('"'));
+    fn next(&mut self, diagnostics: &mut Diagnostics<'a>) -> Result<Option<(Value<'a>, Range<usize>)>, Diagnostic> {
+        if self.rest.is_empty() {
+            return Ok(None);
+        }
 
-        match &self.rest {
+        let (key, key_range) = self.next_single(&['=', ','], diagnostics)?;
+
+        let delim = self.skip_delimiter();
+
+        if let Some('=') = delim {
+            let (val, val_range) = self.next_single(&[','], diagnostics)?;
+            let range = Range { start: key_range.start, end: val_range.end };
+            let res = Some((Value::Double(key, val), range));
+
+            let delim = self.skip_delimiter();
+            assert!(delim == Some(',') || delim == None, "invalid comma seperated key value pair");
+            Ok(res)
+        } else {
+            assert!(delim == Some(',') || delim == None, "invalid comma seperated value");
+            Ok(Some((Value::Single(key), key_range)))
+        }
+    }
+
+    fn next_quoted(&mut self, diagnostics: &mut Diagnostics<'a>) -> Result<(Cow<'a, str>, Range<usize>), Diagnostic> {
+        assert!(self.rest.starts_with('"'));
+        macro_rules! err {
+            ($e:ident) => {{
+                diagnostics
+                    .error("invalid double-quoted string")
+                    .with_error_section(&self.range, "double quoted string starts here")
+                    .note(format!("cause: {}", $e))
+                    .emit();
+                return Err(Diagnostic);
+            }}
+        }
+
+        let (content, quoted_string_len) = match &self.rest {
             Cow::Borrowed(rest) => match quoted_string::parse::<TestSpec>(rest) {
-                // TODO: error handling
-                Err(e) => panic!("Invalid double-quoted string: {:?}", e),
+                Err((_, e)) => err!(e),
                 Ok(parsed) => {
                     self.rest = Cow::Borrowed(parsed.tail);
-                    quoted_string::to_content::<TestSpec>(parsed.quoted_string).unwrap()
+                    let content = quoted_string::to_content::<TestSpec>(parsed.quoted_string).unwrap();
+                    (content, parsed.quoted_string.len())
                 },
             },
             Cow::Owned(rest) => match quoted_string::parse::<TestSpec>(rest) {
-                // TODO: error handling
-                Err(e) => panic!("Invalid double-quoted string: {:?}", e),
+                Err((_, e)) => err!(e),
                 Ok(parsed) => {
                     let content = quoted_string::to_content::<TestSpec>(parsed.quoted_string)
                         .unwrap()
                         .into_owned();
+                    let quoted_string_len = parsed.quoted_string.len();
                     self.rest.truncate_start(self.rest.len() - parsed.tail.len());
-                    Cow::Owned(content)
+                    (Cow::Owned(content), quoted_string_len)
                 },
             },
-        }
+        };
+        let range = Range { start: self.range.start, end: self.range.start + quoted_string_len };
+        self.range.start += quoted_string_len;
+        assert_eq!(self.range.end - self.range.start, self.rest.len());
+        Ok((content, range))
     }
 
-    fn next_unquoted(&mut self, delimiters: &[char]) -> Cow<'a, str> {
+    fn next_unquoted(&mut self, delimiters: &[char]) -> (Cow<'a, str>, Range<usize>) {
         let idx = delimiters
             .iter()
             .cloned()
@@ -226,65 +287,64 @@ impl<'a> Parser<'a> {
             .unwrap_or(self.rest.len());
         let rest = self.rest.split_off(idx);
         let mut val = mem::replace(&mut self.rest, rest);
-        val.trim_inplace();
-        val
+        let self_range = self.range.clone();
+        self.range.start += idx;
+
+        let len = val.len();
+        val.trim_start_inplace();
+        let trimmed_start = len - val.len();
+        val.trim_end_inplace();
+        let trimmed_end = len - trimmed_start - val.len();
+        let range = Range {
+            start: self_range.start + trimmed_start,
+            end: self_range.start + idx - trimmed_end
+        };
+        (val, range)
     }
 
-    fn next_single(&mut self, delimiters: &[char]) -> Cow<'a, str> {
+    fn next_single(
+        &mut self, delimiters: &[char], diagnostics: &mut Diagnostics<'a>
+    ) -> Result<(Cow<'a, str>, Range<usize>), Diagnostic> {
+        let len = self.rest.len();
         self.rest.trim_start_inplace();
-        if self.rest.starts_with('"') { self.next_quoted() } else { self.next_unquoted(delimiters) }
+        self.range.start += len - self.rest.len();
+        if self.rest.starts_with('"') {
+            self.next_quoted(diagnostics)
+        } else {
+            Ok(self.next_unquoted(delimiters))
+        }
     }
 
     fn skip_delimiter(&mut self) -> Option<char> {
+        let len = self.rest.len();
         self.rest.trim_start_inplace();
+        self.range.start += len - self.rest.len();
         let delim = self.rest.chars().next();
         if delim.is_some() {
             self.rest.truncate_start(1);
+            self.range.start += 1;
         }
         delim
-    }
-}
-
-impl<'a> Iterator for Parser<'a> {
-    type Item = Value<'a>;
-
-    fn next(&mut self) -> Option<Value<'a>> {
-        if self.rest.is_empty() {
-            return None;
-        }
-
-        let mut key = self.next_single(&['=', ',']);
-        key.trim_inplace();
-
-        let delim = self.skip_delimiter();
-
-        if let Some('=') = delim {
-            let res = Some(Value::Double(key, self.next_single(&[','])));
-
-            let delim = self.skip_delimiter();
-            assert!(delim == Some(',') || delim == None, "invalid comma seperated key value pair");
-            res
-        } else {
-            // TODO: error handling
-            assert!(delim == Some(',') || delim == None, "invalid comma seperated value");
-            Some(Value::Single(key))
-        }
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::diagnostics::Input;
 
     #[test]
     fn test_parser() {
-        let mut parser = Parser::new(Cow::Borrowed(r#"foo, bar = " baz, \"qux\"", quux"#));
-        assert_eq!(parser.next(), Some(Value::Single(Cow::Borrowed("foo"))));
+        let mut diagnostics = Diagnostics::new("", Input::Stdin);
+        let s = r#"foo, bar = " baz, \"qux\"", quux"#;
+        let s_range = Range { start: 0, end: s.len() };
+        let mut parser = Parser::new(Cow::Borrowed(s), s_range);
+        assert_eq!(parser.next(&mut diagnostics), Some(Value::Single(Cow::Borrowed("foo"))));
         assert_eq!(
-            parser.next(),
+            parser.next(&mut diagnostics),
             Some(Value::Double(Cow::Borrowed("bar"), Cow::Owned(r#" baz, "qux""#.to_string())))
         );
-        assert_eq!(parser.next(), Some(Value::Single(Cow::Borrowed("quux"))));
+        assert_eq!(parser.next(&mut diagnostics), Some(Value::Single(Cow::Borrowed("quux"))));
     }
 
     #[test]

--- a/src/cskvp.rs
+++ b/src/cskvp.rs
@@ -160,7 +160,8 @@ impl<'a> Drop for Cskvp<'a> {
         let mut diag = self
             .diagnostics
             .as_mut()
-            .map(|d| d.warning("in element config").with_error_section(range, ""));
+            .map(|d| d.warning("unknown attributes in element config")
+                .with_info_section(range, "in this element config"));
         if let Some((label, range)) = self.label.as_ref() {
             diag = diag.map(|d| {
                 d.warning(format!("label ignored: {}", label))

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -176,21 +176,21 @@ impl<'a: 'b, 'b> DiagnosticBuilder<'a, 'b> {
         self
     }
 
-    /// message can be empty
-    pub fn with_section<S: Into<String>>(mut self, range: &Range<usize>, message: S) -> Self {
-        let style = if self.labels.len() == 0 {
-            LabelStyle::Primary
-        } else {
-            LabelStyle::Secondary
-        };
+    fn with_section<S: Into<String>>(mut self, style: LabelStyle, range: &Range<usize>, message: S) -> Self {
         let span = self.file_map.span().subspan(ByteOffset(range.start as i64), ByteOffset(range.end as i64));
         let message = message.into();
-        let message = if message.len() > 0 {
-            Some(message)
-        } else {
-            None
-        };
+        let message = Some(message);
         self.labels.push(Label { span, message, style });
         self
+    }
+
+    /// message can be empty
+    pub fn with_error_section<S: Into<String>>(mut self, range: &Range<usize>, message: S) -> Self {
+        self.with_section(LabelStyle::Primary, range, message)
+    }
+
+    /// message can be empty
+    pub fn with_info_section<S: Into<String>>(mut self, range: &Range<usize>, message: S) -> Self {
+        self.with_section(LabelStyle::Secondary, range, message)
     }
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,7 +1,124 @@
-use std::sync::Arc;
+#![allow(unused)]
 
-use codespan::FileMap;
+use std::rc::Rc;
+use std::ops::Range;
+use std::path::PathBuf;
+use url::Url;
 
-pub struct DiagnosticBuilder<'a> {
-    file_map: Arc<FileMap<&'a str>>,
+use codespan::{FileMap, FileName, ByteOffset, Span};
+use codespan_reporting::{Diagnostic, Label, LabelStyle, Severity};
+use codespan_reporting::termcolor::{ColorChoice, StandardStream};
+
+use crate::resolve::Context;
+
+#[derive(Clone, Debug)]
+pub struct Diagnostics<'a> {
+    file_map: Rc<FileMap<&'a str>>,
+}
+
+pub enum Input {
+    File(PathBuf),
+    Stdin,
+    Url(Url),
+}
+
+impl<'a> Diagnostics<'a> {
+    pub fn new(markdown: &'a str, input: Input) -> Diagnostics<'a> {
+        let source = match input {
+            Input::File(path) => FileName::real(path),
+            Input::Stdin => FileName::Virtual("stdin".into()),
+            Input::Url(url) => FileName::Virtual(url.as_str().to_owned().into()),
+        };
+        let file_map = Rc::new(FileMap::new(source, markdown));
+
+        Diagnostics {
+            file_map,
+        }
+    }
+
+    pub fn first_line(&self, range: &Range<usize>) -> Range<usize> {
+        let start = Span::from_offset(self.file_map.span().start(), ByteOffset(range.start as i64)).end();
+        let line = self.file_map.location(start).unwrap().0;
+        let line_span = self.file_map.line_span(line).unwrap();
+        // get rid of newline
+        let len = self.file_map.src_slice(line_span).unwrap().trim_end().len();
+        Range {
+            start: range.start,
+            end: range.start + len,
+        }
+    }
+
+    fn diagnostic(&self, severity: Severity, message: String) -> DiagnosticBuilder<'a, '_> {
+        DiagnosticBuilder {
+            file_map: &self.file_map,
+            severity,
+            message,
+            code: None,
+            labels: Vec::new(),
+        }
+    }
+
+    pub fn bug<S: Into<String>>(&self, message: S) -> DiagnosticBuilder<'a, '_> {
+        self.diagnostic(Severity::Bug, message.into())
+    }
+    pub fn error<S: Into<String>>(&self, message: S) -> DiagnosticBuilder<'a, '_> {
+        self.diagnostic(Severity::Error, message.into())
+    }
+    pub fn warning<S: Into<String>>(&self, message: S) -> DiagnosticBuilder<'a, '_> {
+        self.diagnostic(Severity::Warning, message.into())
+    }
+    pub fn note<S: Into<String>>(&self, message: S) -> DiagnosticBuilder<'a, '_> {
+        self.diagnostic(Severity::Note, message.into())
+    }
+    pub fn help<S: Into<String>>(&self, message: S) -> DiagnosticBuilder<'a, '_> {
+        self.diagnostic(Severity::Help, message.into())
+    }
+}
+
+#[must_use = "call `emit` to emit the diagnostic"]
+pub struct DiagnosticBuilder<'a: 'b, 'b> {
+    file_map: &'b FileMap<&'a str>,
+    severity: Severity,
+    message: String,
+    code: Option<String>,
+    labels: Vec<Label>,
+}
+
+impl<'a: 'b, 'b> DiagnosticBuilder<'a, 'b> {
+    pub fn with_error_code(mut self, code: String) -> Self {
+        self.code = Some(code);
+        self
+    }
+
+    /// message can be empty
+    pub fn with_section<S: Into<String>>(mut self, range: &Range<usize>, message: S) -> Self {
+        let style = if self.labels.len() == 0 {
+            LabelStyle::Primary
+        } else {
+            LabelStyle::Secondary
+        };
+        let span = self.file_map.span().subspan(ByteOffset(range.start as i64), ByteOffset(range.end as i64));
+        let message = message.into();
+        let message = if message.len() > 0 {
+            Some(message)
+        } else {
+            None
+        };
+        self.labels.push(Label { span, message, style });
+        self
+    }
+
+    pub fn emit(self) {
+        let Self { file_map, severity, message, code, labels } = self;
+        // TODO: make this configurable
+        let out = StandardStream::stderr(ColorChoice::Auto);
+
+        // ignore output errors, because where would we log them anyway?!
+        let _ = codespan_reporting::emit_single(out, file_map, &Diagnostic {
+            severity,
+            code,
+            message,
+            labels,
+        });
+    }
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,7 @@
+use std::sync::Arc;
+
+use codespan::FileMap;
+
+pub struct DiagnosticBuilder<'a> {
+    file_map: Arc<FileMap<&'a str>>,
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -88,19 +88,19 @@ impl<'a> Diagnostics<'a> {
     }
 
     pub fn bug<S: Into<String>>(&mut self, message: S) -> DiagnosticBuilder<'a, '_> {
-        let mut diag = self.diagnostic(Severity::Bug, message.into())
-            .note("please report this");
+        let mut diag = Some(self.diagnostic(Severity::Bug, message.into())
+            .note("please report this"));
         backtrace::trace(|frame| {
             let ip = frame.ip();
             backtrace::resolve(ip, |symbol| {
-                diag = diag.note(format!(
+                diag = Some(diag.take().unwrap().note(format!(
                     "in heradoc file {:?} name {:?} line {:?} address {:?}",
                     symbol.filename(), symbol.name(), symbol.lineno(), symbol.addr()
-                ));
+                )));
             });
             true
         });
-        diag
+        diag.unwrap()
     }
     pub fn error<S: Into<String>>(&mut self, message: S) -> DiagnosticBuilder<'a, '_> {
         self.diagnostic(Severity::Error, message.into())

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,9 @@ pub type FatalResult<T> = result::Result<T, Fatal>;
 pub enum Fatal {
     /// Output file write error.
     Output(io::Error),
+
+    /// An unrecoverable internal error.
+    InternalError,
 }
 
 impl From<io::Error> for Fatal {
@@ -24,6 +27,7 @@ impl std::error::Error for Fatal {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Fatal::Output(io) => Some(io),
+            Fatal::InteralCompilerError => None,
         }
     }
 }
@@ -32,6 +36,7 @@ impl fmt::Display for Fatal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Fatal::Output(io) => write!(f, "output file write error: {}", io),
+            Fatal::InteralCompilerError => write!(f, "can not continue due to internal error"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,37 @@
+use std::io;
+use std::result;
+
+#[must_use]
+pub type Result<T> = result::Result<T, Error>;
+#[must_use]
+pub type FatalResult<T> = result::Result<T, Fatal>;
+
+#[must_use]
+pub enum Fatal {
+    /// Output file write error.
+    Output(io::Error),
+}
+
+impl From<io::Error> for Fatal {
+    fn from(err: io::Error) -> Self {
+        Fatal::Output(err)
+    }
+}
+
+#[must_use]
+pub enum Error {
+    /// Fatal unrecoverable error, but somewhat expected.
+    Fatal(Fatal),
+    /// Diagnostic was printed, event wasn't handled, skip over the event.
+    ///
+    /// This means that the error was already handled internally and is used to inform the caller
+    /// about it. It allows the generator to skip over events, if an error happens e.g. in an
+    /// `Event::Start`.
+    Diagnostic,
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::Fatal(err.into())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,8 +13,15 @@ pub enum Fatal {
     /// Output file write error.
     Output(io::Error),
 
-    /// An unrecoverable internal error.
-    InternalError,
+    /// An unrecoverable internal error (ICE).
+    ///
+    /// Used for assertions that are made but not completely or badly proven. For cases where this
+    /// can be related directly to an particular structure in an input file this error also
+    /// provides opportunities to log the relevant context in diagnostics as opposed to `unwrap` or
+    /// `expect` panicking.  For example this may occur due to an interface of a dependency being
+    /// more general than its usage herein but we can not expect full control over its
+    /// implementation.
+    InteralCompilerError,
 }
 
 impl From<io::Error> for Fatal {

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,3 +35,9 @@ impl From<io::Error> for Error {
         Error::Fatal(err.into())
     }
 }
+
+impl From<Fatal> for Error {
+    fn from(err: Fatal) -> Self {
+        Error::Fatal(err)
+    }
+}

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -25,6 +25,7 @@ pub trait VecExt<T> {
 
 impl<A, B> VecExt<A> for Vec<(A, B)> {
     type Output = (A, B);
+
     fn remove_element<U>(&mut self, element: &U) -> Option<(A, B)>
     where
         A: PartialEq<U>,

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use crate::frontend::range::WithRange;
+
 pub trait StrExt {
     fn starts_with_ignore_ascii_case(&self, other: &Self) -> bool;
 }
@@ -23,15 +25,14 @@ pub trait VecExt<T> {
         U: ?Sized;
 }
 
-impl<A, B> VecExt<A> for Vec<(A, B)> {
-    type Output = (A, B);
-
-    fn remove_element<U>(&mut self, element: &U) -> Option<(A, B)>
-    where
-        A: PartialEq<U>,
-        U: ?Sized,
+impl<T> VecExt<T> for Vec<WithRange<T>> {
+    type Output = WithRange<T>;
+    fn remove_element<U>(&mut self, element: &U) -> Option<Self::Output>
+        where
+            T: PartialEq<U>,
+            U: ?Sized
     {
-        let pos = self.iter().position(|(a, _)| *a == *element)?;
+        let pos = self.iter().position(|a| *a.as_ref().element() == *element)?;
         Some(self.remove(pos))
     }
 }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -16,19 +16,21 @@ impl StrExt for str {
 
 // https://github.com/rust-lang/rust/issues/40062
 pub trait VecExt<T> {
-    fn remove_element<U>(&mut self, element: &U) -> Option<T>
+    type Output;
+    fn remove_element<U>(&mut self, element: &U) -> Option<Self::Output>
     where
         T: PartialEq<U>,
         U: ?Sized;
 }
 
-impl<T> VecExt<T> for Vec<T> {
-    fn remove_element<U>(&mut self, element: &U) -> Option<T>
+impl<A, B> VecExt<A> for Vec<(A, B)> {
+    type Output = (A, B);
+    fn remove_element<U>(&mut self, element: &U) -> Option<(A, B)>
     where
-        T: PartialEq<U>,
+        A: PartialEq<U>,
         U: ?Sized,
     {
-        let pos = self.iter().position(|s| *s == *element)?;
+        let pos = self.iter().position(|(a, _)| *a == *element)?;
         Some(self.remove(pos))
     }
 }

--- a/src/frontend/concat.rs
+++ b/src/frontend/concat.rs
@@ -5,15 +5,15 @@ use std::ops::Range;
 use super::convert_cow::{ConvertCow, Event};
 use str_concat;
 
-pub struct Concat<'a>(Peekable<ConvertCow<'a>);
+pub struct Concat<'a>(Peekable<ConvertCow<'a>>);
 
 impl<'a> Concat<'a> {
-    pub fn new(i: I) -> Self {
+    pub fn new(i: ConvertCow<'a>) -> Self {
         Concat(i.peekable())
     }
 }
 
-impl<'a, I: Iterator<Item = (Event<'a>, Range<usize>)>> Iterator for Concat<'a, I> {
+impl<'a> Iterator for Concat<'a> {
     type Item = (Event<'a>, Range<usize>);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/frontend/concat.rs
+++ b/src/frontend/concat.rs
@@ -2,12 +2,12 @@ use std::borrow::Cow;
 use std::iter::Peekable;
 use std::ops::Range;
 
-use super::convert_cow::Event;
+use super::convert_cow::{ConvertCow, Event};
 use str_concat;
 
-pub struct Concat<'a, I: Iterator<Item = (Event<'a>, Range<usize>)>>(Peekable<I>);
+pub struct Concat<'a>(Peekable<ConvertCow<'a>);
 
-impl<'a, I: Iterator<Item = (Event<'a>, Range<usize>)>> Concat<'a, I> {
+impl<'a> Concat<'a> {
     pub fn new(i: I) -> Self {
         Concat(i.peekable())
     }

--- a/src/frontend/convert_cow.rs
+++ b/src/frontend/convert_cow.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::ops::Range;
 
 use pulldown_cmark::{
     Alignment,
@@ -10,13 +9,15 @@ use pulldown_cmark::{
     Tag as CmarkTag,
 };
 
+use crate::frontend::range::WithRange;
+
 pub struct ConvertCow<'a>(pub OffsetIter<'a>);
 
 impl<'a> Iterator for ConvertCow<'a> {
-    type Item = (Event<'a>, Range<usize>);
+    type Item = WithRange<Event<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(e, r)| (e.into(), r))
+        self.0.next().map(|(e, r)| WithRange(e.into(), r.into()))
     }
 }
 

--- a/src/frontend/convert_cow.rs
+++ b/src/frontend/convert_cow.rs
@@ -1,14 +1,15 @@
 use std::borrow::Cow;
+use std::ops::Range;
 
-use pulldown_cmark::{Alignment, CowStr, Event as CmarkEvent, LinkType, Parser, Tag as CmarkTag};
+use pulldown_cmark::{Alignment, CowStr, Event as CmarkEvent, LinkType, OffsetIter, Tag as CmarkTag};
 
-pub struct ConvertCow<'a>(pub Parser<'a>);
+pub struct ConvertCow<'a>(pub OffsetIter<'a>);
 
 impl<'a> Iterator for ConvertCow<'a> {
-    type Item = Event<'a>;
+    type Item = (Event<'a>, Range<usize>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(Into::into)
+        self.0.next().map(|(e, r)| (e.into(), r))
     }
 }
 

--- a/src/frontend/convert_cow.rs
+++ b/src/frontend/convert_cow.rs
@@ -1,7 +1,14 @@
 use std::borrow::Cow;
 use std::ops::Range;
 
-use pulldown_cmark::{Alignment, CowStr, Event as CmarkEvent, LinkType, OffsetIter, Tag as CmarkTag};
+use pulldown_cmark::{
+    Alignment,
+    CowStr,
+    Event as CmarkEvent,
+    LinkType,
+    OffsetIter,
+    Tag as CmarkTag,
+};
 
 pub struct ConvertCow<'a>(pub OffsetIter<'a>);
 

--- a/src/frontend/event.rs
+++ b/src/frontend/event.rs
@@ -2,10 +2,13 @@ use std::borrow::Cow;
 
 pub use pulldown_cmark::Alignment;
 
+use enum_kinds::EnumKind;
+
 use crate::resolve::Command;
 
 // extension of pulldown_cmark::Event with custom types
-#[derive(Debug)]
+#[derive(Debug, EnumKind)]
+#[enum_kind(EventKind)]
 pub enum Event<'a> {
     Start(Tag<'a>),
     End(Tag<'a>),

--- a/src/frontend/event.rs
+++ b/src/frontend/event.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::ops::Range;
 
 pub use pulldown_cmark::Alignment;
 
@@ -99,15 +100,15 @@ pub enum Tag<'a> {
 
 #[derive(Debug, Clone)]
 pub struct Header<'a> {
-    pub label: Cow<'a, str>,
+    pub label: (Cow<'a, str>, Range<usize>),
     pub level: i32,
 }
 
 #[derive(Debug, Clone)]
 pub struct CodeBlock<'a> {
-    pub label: Option<Cow<'a, str>>,
-    pub caption: Option<Cow<'a, str>>,
-    pub language: Option<Cow<'a, str>>,
+    pub label: Option<(Cow<'a, str>, Range<usize>)>,
+    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
+    pub language: Option<(Cow<'a, str>, Range<usize>)>,
 }
 
 #[derive(Debug, Clone)]
@@ -122,41 +123,41 @@ pub struct FootnoteDefinition<'a> {
 
 #[derive(Debug, Clone)]
 pub struct Figure<'a> {
-    pub label: Option<Cow<'a, str>>,
-    pub caption: Option<Cow<'a, str>>,
+    pub label: Option<(Cow<'a, str>, Range<usize>)>,
+    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Table<'a> {
-    pub label: Option<Cow<'a, str>>,
-    pub caption: Option<Cow<'a, str>>,
+    pub label: Option<(Cow<'a, str>, Range<usize>)>,
+    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
     pub alignment: Vec<Alignment>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Include<'a> {
-    pub label: Option<Cow<'a, str>>,
-    pub caption: Option<Cow<'a, str>>,
+    pub label: Option<(Cow<'a, str>, Range<usize>)>,
+    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
     pub title: Option<Cow<'a, str>>,
     /// rendered already
     pub alt_text: Option<String>,
     pub dst: Cow<'a, str>,
-    pub scale: Option<Cow<'a, str>>,
-    pub width: Option<Cow<'a, str>>,
-    pub height: Option<Cow<'a, str>>,
+    pub scale: Option<(Cow<'a, str>, Range<usize>)>,
+    pub width: Option<(Cow<'a, str>, Range<usize>)>,
+    pub height: Option<(Cow<'a, str>, Range<usize>)>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Equation<'a> {
-    pub label: Option<Cow<'a, str>>,
-    pub caption: Option<Cow<'a, str>>,
+    pub label: Option<(Cow<'a, str>, Range<usize>)>,
+    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Graphviz<'a> {
-    pub label: Option<Cow<'a, str>>,
-    pub caption: Option<Cow<'a, str>>,
-    pub scale: Option<Cow<'a, str>>,
-    pub width: Option<Cow<'a, str>>,
-    pub height: Option<Cow<'a, str>>,
+    pub label: Option<(Cow<'a, str>, Range<usize>)>,
+    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
+    pub scale: Option<(Cow<'a, str>, Range<usize>)>,
+    pub width: Option<(Cow<'a, str>, Range<usize>)>,
+    pub height: Option<(Cow<'a, str>, Range<usize>)>,
 }

--- a/src/frontend/event.rs
+++ b/src/frontend/event.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
-use std::ops::Range;
 
 pub use pulldown_cmark::Alignment;
 
 use enum_kinds::EnumKind;
 
+use crate::frontend::range::WithRange;
 use crate::resolve::Command;
 
 // extension of pulldown_cmark::Event with custom types
@@ -100,15 +100,15 @@ pub enum Tag<'a> {
 
 #[derive(Debug, Clone)]
 pub struct Header<'a> {
-    pub label: (Cow<'a, str>, Range<usize>),
+    pub label: WithRange<Cow<'a, str>>,
     pub level: i32,
 }
 
 #[derive(Debug, Clone)]
 pub struct CodeBlock<'a> {
-    pub label: Option<(Cow<'a, str>, Range<usize>)>,
-    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
-    pub language: Option<(Cow<'a, str>, Range<usize>)>,
+    pub label: Option<WithRange<Cow<'a, str>>>,
+    pub caption: Option<WithRange<Cow<'a, str>>>,
+    pub language: Option<WithRange<Cow<'a, str>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -123,41 +123,41 @@ pub struct FootnoteDefinition<'a> {
 
 #[derive(Debug, Clone)]
 pub struct Figure<'a> {
-    pub label: Option<(Cow<'a, str>, Range<usize>)>,
-    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
+    pub label: Option<WithRange<Cow<'a, str>>>,
+    pub caption: Option<WithRange<Cow<'a, str>>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Table<'a> {
-    pub label: Option<(Cow<'a, str>, Range<usize>)>,
-    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
+    pub label: Option<WithRange<Cow<'a, str>>>,
+    pub caption: Option<WithRange<Cow<'a, str>>>,
     pub alignment: Vec<Alignment>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Include<'a> {
-    pub label: Option<(Cow<'a, str>, Range<usize>)>,
-    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
+    pub label: Option<WithRange<Cow<'a, str>>>,
+    pub caption: Option<WithRange<Cow<'a, str>>>,
     pub title: Option<Cow<'a, str>>,
     /// rendered already
     pub alt_text: Option<String>,
     pub dst: Cow<'a, str>,
-    pub scale: Option<(Cow<'a, str>, Range<usize>)>,
-    pub width: Option<(Cow<'a, str>, Range<usize>)>,
-    pub height: Option<(Cow<'a, str>, Range<usize>)>,
+    pub scale: Option<WithRange<Cow<'a, str>>>,
+    pub width: Option<WithRange<Cow<'a, str>>>,
+    pub height: Option<WithRange<Cow<'a, str>>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Equation<'a> {
-    pub label: Option<(Cow<'a, str>, Range<usize>)>,
-    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
+    pub label: Option<WithRange<Cow<'a, str>>>,
+    pub caption: Option<WithRange<Cow<'a, str>>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Graphviz<'a> {
-    pub label: Option<(Cow<'a, str>, Range<usize>)>,
-    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
-    pub scale: Option<(Cow<'a, str>, Range<usize>)>,
-    pub width: Option<(Cow<'a, str>, Range<usize>)>,
-    pub height: Option<(Cow<'a, str>, Range<usize>)>,
+    pub label: Option<WithRange<Cow<'a, str>>>,
+    pub caption: Option<WithRange<Cow<'a, str>>>,
+    pub scale: Option<WithRange<Cow<'a, str>>>,
+    pub width: Option<WithRange<Cow<'a, str>>>,
+    pub height: Option<WithRange<Cow<'a, str>>>,
 }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -319,9 +319,9 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
                     .error("Code has both prefix and inline style labels / config")
                     .with_section(&code_block_cskvp_range, "config specified here")
                     .with_section(cskvp_range, "but config also specified here")
+                    .note("ignoring both")
+                    .help("try removing one of them")
                     .emit();
-                self.diagnostics.note("ignoring both").emit();
-                self.diagnostics.help("try removing one of them").emit();
                 c.clear();
             } else {
                 let cskvp = Cskvp::new(Cow::Borrowed(&lang[pos + 1..]));

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -30,7 +30,7 @@ use crate::resolve::Command;
 pub struct Frontend<'a, B: Backend<'a>> {
     cfg: &'a Config,
     diagnostics: Diagnostics<'a>,
-    parser: Peekable<Concat<'a, ConvertCow<'a>>>,
+    parser: Peekable<Concat<'a>>,
     buffer: VecDeque<(Event<'a>, Range<usize>)>,
     marker: PhantomData<B>,
 }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -321,7 +321,6 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
             language = &lang[..pos];
             let code_block_cskvp_range = self.diagnostics.first_line(&range);
             if let Some(c) = &mut cskvp {
-                // TODO: error
                 self.diagnostics
                     .error("code has both prefix and inline style labels / config")
                     .with_section(&code_block_cskvp_range, "config specified here")

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::iter::Peekable;
-use std::marker::PhantomData;
 use std::str::FromStr;
 use std::ops::Range;
 
@@ -27,15 +26,14 @@ use crate::diagnostics::Diagnostics;
 use crate::ext::{CowExt, StrExt};
 use crate::resolve::Command;
 
-pub struct Frontend<'a, B: Backend<'a>> {
+pub struct Frontend<'a> {
     cfg: &'a Config,
     diagnostics: Diagnostics<'a>,
     parser: Peekable<Concat<'a>>,
     buffer: VecDeque<(Event<'a>, Range<usize>)>,
-    marker: PhantomData<B>,
 }
 
-impl<'a, B: Backend<'a>> Iterator for Frontend<'a, B> {
+impl<'a> Iterator for Frontend<'a> {
     type Item = (Event<'a>, Range<usize>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -63,8 +61,8 @@ fn broken_link_callback(normalized_ref: &str, text_ref: &str) -> Option<(String,
     }
 }
 
-impl<'a, B: Backend<'a>> Frontend<'a, B> {
-    pub fn new(cfg: &'a Config, markdown: &'a str, diagnostics: Diagnostics<'a>) -> Frontend<'a, B> {
+impl<'a> Frontend<'a> {
+    pub fn new(cfg: &'a Config, markdown: &'a str, diagnostics: Diagnostics<'a>) -> Frontend<'a> {
         let parser = CmarkParser::new_with_broken_link_callback(
             markdown,
             CmarkOptions::ENABLE_FOOTNOTES
@@ -78,7 +76,6 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
             diagnostics,
             parser: Concat::new(ConvertCow(parser)).peekable(),
             buffer: VecDeque::new(),
-            marker: PhantomData,
         }
     }
 

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -3,12 +3,11 @@ use std::collections::VecDeque;
 use std::iter::Peekable;
 use std::marker::PhantomData;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::ops::Range;
 
 use lazy_static::lazy_static;
 use pulldown_cmark::{Options as CmarkOptions, Parser as CmarkParser};
 use regex::Regex;
-use codespan::FileMap;
 
 mod concat;
 mod convert_cow;
@@ -24,27 +23,28 @@ use self::refs::ReferenceParseResult;
 use crate::backend::Backend;
 use crate::config::Config;
 use crate::cskvp::Cskvp;
+use crate::diagnostics::Diagnostics;
 use crate::ext::{CowExt, StrExt};
 use crate::resolve::Command;
 
 pub struct Frontend<'a, B: Backend<'a>> {
     cfg: &'a Config,
-    file_map: Arc<FileMap<&'a str>>,
+    diagnostics: Diagnostics<'a>,
     parser: Peekable<Concat<'a, ConvertCow<'a>>>,
-    buffer: VecDeque<Event<'a>>,
+    buffer: VecDeque<(Event<'a>, Range<usize>)>,
     marker: PhantomData<B>,
 }
 
 impl<'a, B: Backend<'a>> Iterator for Frontend<'a, B> {
-    type Item = Event<'a>;
+    type Item = (Event<'a>, Range<usize>);
 
-    fn next(&mut self) -> Option<Event<'a>> {
-        if let Some(evt) = self.buffer.pop_front() {
-            return Some(evt);
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((evt, range)) = self.buffer.pop_front() {
+            return Some((evt, range));
         }
 
-        let evt = self.parser.next()?;
-        self.convert_event(evt);
+        let (evt, range) = self.parser.next()?;
+        self.convert_event(evt, range);
         self.buffer.pop_front()
     }
 }
@@ -63,7 +63,7 @@ fn broken_link_callback(normalized_ref: &str, text_ref: &str) -> Option<(String,
 }
 
 impl<'a, B: Backend<'a>> Frontend<'a, B> {
-    pub fn new(cfg: &'a Config, markdown: &'a str, file_map: Arc<FileMap<&'a str>>) -> Frontend<'a, B> {
+    pub fn new(cfg: &'a Config, markdown: &'a str, diagnostics: Diagnostics<'a>) -> Frontend<'a, B> {
         let parser = CmarkParser::new_with_broken_link_callback(
             markdown,
             CmarkOptions::ENABLE_FOOTNOTES
@@ -71,114 +71,114 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
                 | CmarkOptions::ENABLE_STRIKETHROUGH
                 | CmarkOptions::ENABLE_TASKLISTS,
             Some(&broken_link_callback),
-        );
+        ).into_offset_iter();
         Frontend {
             cfg,
-            file_map,
+            diagnostics,
             parser: Concat::new(ConvertCow(parser)).peekable(),
             buffer: VecDeque::new(),
             marker: PhantomData,
         }
     }
 
-    fn convert_event(&mut self, evt: CmarkEvent<'a>) {
+    fn convert_event(&mut self, evt: CmarkEvent<'a>, range: Range<usize>) {
         match evt {
-            CmarkEvent::Text(text) => self.buffer.push_back(Event::Text(text)),
-            CmarkEvent::Html(html) => self.buffer.push_back(Event::Html(html)),
-            CmarkEvent::InlineHtml(html) => self.convert_inline_html(html),
+            CmarkEvent::Text(text) => self.buffer.push_back((Event::Text(text), range)),
+            CmarkEvent::Html(html) => self.buffer.push_back((Event::Html(html), range)),
+            CmarkEvent::InlineHtml(html) => self.convert_inline_html(html, range),
             CmarkEvent::FootnoteReference(label) => {
-                self.buffer.push_back(Event::FootnoteReference(FootnoteReference { label }))
+                self.buffer.push_back((Event::FootnoteReference(FootnoteReference { label }), range))
             },
-            CmarkEvent::SoftBreak => self.buffer.push_back(Event::SoftBreak),
-            CmarkEvent::HardBreak => self.buffer.push_back(Event::HardBreak),
+            CmarkEvent::SoftBreak => self.buffer.push_back((Event::SoftBreak, range)),
+            CmarkEvent::HardBreak => self.buffer.push_back((Event::HardBreak, range)),
             CmarkEvent::TaskListMarker(checked) => {
-                self.buffer.push_back(Event::TaskListMarker(TaskListMarker { checked }))
+                self.buffer.push_back((Event::TaskListMarker(TaskListMarker { checked }), range))
             },
 
             // TODO: make this not duplicate
-            CmarkEvent::Start(CmarkTag::Rule) => self.buffer.push_back(Event::Start(Tag::Rule)),
-            CmarkEvent::End(CmarkTag::Rule) => self.buffer.push_back(Event::End(Tag::Rule)),
+            CmarkEvent::Start(CmarkTag::Rule) => self.buffer.push_back((Event::Start(Tag::Rule), range)),
+            CmarkEvent::End(CmarkTag::Rule) => self.buffer.push_back((Event::End(Tag::Rule), range)),
             CmarkEvent::Start(CmarkTag::BlockQuote) => {
-                self.buffer.push_back(Event::Start(Tag::BlockQuote))
+                self.buffer.push_back((Event::Start(Tag::BlockQuote), range))
             },
             CmarkEvent::End(CmarkTag::BlockQuote) => {
-                self.buffer.push_back(Event::End(Tag::BlockQuote))
+                self.buffer.push_back((Event::End(Tag::BlockQuote), range))
             },
             CmarkEvent::Start(CmarkTag::List(start_number)) if start_number.is_none() => {
-                self.buffer.push_back(Event::Start(Tag::List))
+                self.buffer.push_back((Event::Start(Tag::List), range))
             },
             CmarkEvent::End(CmarkTag::List(start_number)) if start_number.is_none() => {
-                self.buffer.push_back(Event::End(Tag::List))
+                self.buffer.push_back((Event::End(Tag::List), range))
             },
             CmarkEvent::Start(CmarkTag::List(start_number)) => {
-                self.buffer.push_back(Event::Start(Tag::Enumerate(Enumerate {
+                self.buffer.push_back((Event::Start(Tag::Enumerate(Enumerate {
                     start_number: start_number.unwrap(),
-                })))
+                })), range))
             },
             CmarkEvent::End(CmarkTag::List(start_number)) => {
-                self.buffer.push_back(Event::End(Tag::Enumerate(Enumerate {
+                self.buffer.push_back((Event::End(Tag::Enumerate(Enumerate {
                     start_number: start_number.unwrap(),
-                })))
+                })), range))
             },
-            CmarkEvent::Start(CmarkTag::Item) => self.buffer.push_back(Event::Start(Tag::Item)),
-            CmarkEvent::End(CmarkTag::Item) => self.buffer.push_back(Event::End(Tag::Item)),
+            CmarkEvent::Start(CmarkTag::Item) => self.buffer.push_back((Event::Start(Tag::Item), range)),
+            CmarkEvent::End(CmarkTag::Item) => self.buffer.push_back((Event::End(Tag::Item), range)),
             CmarkEvent::Start(CmarkTag::FootnoteDefinition(label)) => self
                 .buffer
-                .push_back(Event::Start(Tag::FootnoteDefinition(FootnoteDefinition { label }))),
+                .push_back((Event::Start(Tag::FootnoteDefinition(FootnoteDefinition { label })), range)),
             CmarkEvent::End(CmarkTag::FootnoteDefinition(label)) => self
                 .buffer
-                .push_back(Event::End(Tag::FootnoteDefinition(FootnoteDefinition { label }))),
+                .push_back((Event::End(Tag::FootnoteDefinition(FootnoteDefinition { label })), range)),
             CmarkEvent::Start(CmarkTag::HtmlBlock) => {
-                self.buffer.push_back(Event::Start(Tag::HtmlBlock))
+                self.buffer.push_back((Event::Start(Tag::HtmlBlock), range))
             },
             CmarkEvent::End(CmarkTag::HtmlBlock) => {
-                self.buffer.push_back(Event::End(Tag::HtmlBlock))
+                self.buffer.push_back((Event::End(Tag::HtmlBlock), range))
             },
             CmarkEvent::Start(CmarkTag::TableHead) => {
-                self.buffer.push_back(Event::Start(Tag::TableHead))
+                self.buffer.push_back((Event::Start(Tag::TableHead), range))
             },
             CmarkEvent::End(CmarkTag::TableHead) => {
-                self.buffer.push_back(Event::End(Tag::TableHead))
+                self.buffer.push_back((Event::End(Tag::TableHead), range))
             },
             CmarkEvent::Start(CmarkTag::TableRow) => {
-                self.buffer.push_back(Event::Start(Tag::TableRow))
+                self.buffer.push_back((Event::Start(Tag::TableRow), range))
             },
-            CmarkEvent::End(CmarkTag::TableRow) => self.buffer.push_back(Event::End(Tag::TableRow)),
+            CmarkEvent::End(CmarkTag::TableRow) => self.buffer.push_back((Event::End(Tag::TableRow), range)),
             CmarkEvent::Start(CmarkTag::TableCell) => {
-                self.buffer.push_back(Event::Start(Tag::TableCell))
+                self.buffer.push_back((Event::Start(Tag::TableCell), range))
             },
             CmarkEvent::End(CmarkTag::TableCell) => {
-                self.buffer.push_back(Event::End(Tag::TableCell))
+                self.buffer.push_back((Event::End(Tag::TableCell), range))
             },
             CmarkEvent::Start(CmarkTag::Emphasis) => {
-                self.buffer.push_back(Event::Start(Tag::InlineEmphasis))
+                self.buffer.push_back((Event::Start(Tag::InlineEmphasis), range))
             },
             CmarkEvent::End(CmarkTag::Emphasis) => {
-                self.buffer.push_back(Event::End(Tag::InlineEmphasis))
+                self.buffer.push_back((Event::End(Tag::InlineEmphasis), range))
             },
             CmarkEvent::Start(CmarkTag::Strong) => {
-                self.buffer.push_back(Event::Start(Tag::InlineStrong))
+                self.buffer.push_back((Event::Start(Tag::InlineStrong), range))
             },
             CmarkEvent::End(CmarkTag::Strong) => {
-                self.buffer.push_back(Event::End(Tag::InlineStrong))
+                self.buffer.push_back((Event::End(Tag::InlineStrong), range))
             },
             CmarkEvent::Start(CmarkTag::Strikethrough) => {
-                self.buffer.push_back(Event::Start(Tag::InlineStrikethrough))
+                self.buffer.push_back((Event::Start(Tag::InlineStrikethrough), range))
             },
             CmarkEvent::End(CmarkTag::Strikethrough) => {
-                self.buffer.push_back(Event::End(Tag::InlineStrikethrough))
+                self.buffer.push_back((Event::End(Tag::InlineStrikethrough), range))
             },
 
-            CmarkEvent::Start(CmarkTag::Code) => self.convert_inline_code(),
-            CmarkEvent::Start(CmarkTag::CodeBlock(lang)) => self.convert_code_block(lang, None),
-            CmarkEvent::Start(CmarkTag::Paragraph) => self.convert_paragraph(),
-            CmarkEvent::Start(CmarkTag::Header(level)) => self.convert_header(level, None),
-            CmarkEvent::Start(CmarkTag::Table(alignment)) => self.convert_table(alignment, None),
+            CmarkEvent::Start(CmarkTag::Code) => self.convert_inline_code(range),
+            CmarkEvent::Start(CmarkTag::CodeBlock(lang)) => self.convert_code_block(lang, range, None),
+            CmarkEvent::Start(CmarkTag::Paragraph) => self.convert_paragraph(range),
+            CmarkEvent::Start(CmarkTag::Header(level)) => self.convert_header(level, range, None),
+            CmarkEvent::Start(CmarkTag::Table(alignment)) => self.convert_table(alignment, range, None),
             CmarkEvent::Start(CmarkTag::Link(typ, dst, title)) => {
-                self.convert_link(typ, dst, title)
+                self.convert_link(typ, dst, title, range)
             },
             CmarkEvent::Start(CmarkTag::Image(typ, dst, title)) => {
-                self.convert_image(typ, dst, title, None)
+                self.convert_image(typ, dst, title, range, None)
             },
 
             CmarkEvent::End(CmarkTag::Code)
@@ -193,11 +193,11 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
         }
     }
 
-    fn convert_inline_html(&mut self, html: Cow<'a, str>) {
+    fn convert_inline_html(&mut self, html: Cow<'a, str>, range: Range<usize>) {
         // TODO: proper HTML tag parsing
         match html.as_ref() {
-            "<br>" | "<br/>" | "<br />" => self.buffer.push_back(Event::HardBreak),
-            _ => self.buffer.push_back(Event::InlineHtml(html)),
+            "<br>" | "<br/>" | "<br />" => self.buffer.push_back((Event::HardBreak, range)),
+            _ => self.buffer.push_back((Event::InlineHtml(html), range)),
         }
     }
 
@@ -207,7 +207,7 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
     fn convert_until_end_inclusive(&mut self, f: impl Fn(&CmarkTag<'_>) -> bool) -> String {
         let mut text = String::new();
         loop {
-            let evt = self.parser.next().unwrap();
+            let (evt, range) = self.parser.next().unwrap();
             match &evt {
                 CmarkEvent::End(tag) if f(tag) => return text,
                 CmarkEvent::Text(t) => {
@@ -219,7 +219,7 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
                 _ => (),
             }
 
-            self.convert_event(evt);
+            self.convert_event(evt, range);
         }
     }
 
@@ -228,7 +228,7 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
     fn consume_until_end_inclusive(&mut self) {
         let mut nest = 0;
         loop {
-            match self.parser.next().unwrap() {
+            match self.parser.next().unwrap().0 {
                 CmarkEvent::Start(_) => nest += 1,
                 CmarkEvent::End(_) if nest > 0 => nest -= 1,
                 CmarkEvent::End(_) => return,
@@ -243,7 +243,7 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
         let mut s = String::with_capacity(100);
         let mut nest = 0;
         loop {
-            match self.parser.next().unwrap() {
+            match self.parser.next().unwrap().0 {
                 CmarkEvent::Start(_) => nest += 1,
                 CmarkEvent::End(_) if nest > 0 => nest -= 1,
                 CmarkEvent::End(_) => break,
@@ -258,13 +258,14 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
         s
     }
 
-    fn convert_inline_code(&mut self) {
+    fn convert_inline_code(&mut self, range: Range<usize>) {
         // check if code is math mode
-        let mut text = match self.parser.next().unwrap() {
+        let (evt, _text_range) = self.parser.next().unwrap();
+        let mut text = match evt {
             CmarkEvent::Text(text) => text,
             CmarkEvent::End(CmarkTag::Code) => {
-                self.buffer.push_back(Event::Start(Tag::InlineCode));
-                self.buffer.push_back(Event::End(Tag::InlineCode));
+                self.buffer.push_back((Event::Start(Tag::InlineCode), range.clone()));
+                self.buffer.push_back((Event::End(Tag::InlineCode), range));
                 return;
             },
             e => unreachable!(
@@ -283,11 +284,11 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
                 '\\' => {
                     // latex
                     text.truncate_start(2);
-                    match self.parser.next().unwrap() {
+                    match self.parser.next().unwrap().0 {
                         CmarkEvent::End(CmarkTag::Code) => (),
                         _ => unreachable!("InlineCode should only contain a single text event"),
                     }
-                    self.buffer.push_back(Event::Latex(text));
+                    self.buffer.push_back((Event::Latex(text), range));
                     return;
                 },
                 _ => Tag::InlineCode,
@@ -295,13 +296,13 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
         } else {
             Tag::InlineCode
         };
-        self.buffer.push_back(Event::Start(tag.clone()));
-        self.buffer.push_back(Event::Text(text));
+        self.buffer.push_back((Event::Start(tag.clone()), range.clone()));
+        self.buffer.push_back((Event::Text(text), range.clone()));
         self.convert_until_end_inclusive(|t| if let CmarkTag::Code = t { true } else { false });
-        self.buffer.push_back(Event::End(tag));
+        self.buffer.push_back((Event::End(tag), range));
     }
 
-    fn convert_code_block(&mut self, lang: Cow<'a, str>, mut cskvp: Option<Cskvp<'a>>) {
+    fn convert_code_block(&mut self, lang: Cow<'a, str>, range: Range<usize>, mut cskvp: Option<(Cskvp<'a>, Range<usize>)>) {
         let lang = match lang {
             Cow::Borrowed(s) => s,
             Cow::Owned(_) => unreachable!("CodeBlock language should be borrowed"),
@@ -311,16 +312,24 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
         let language;
         if let Some(pos) = lang.find(',') {
             language = &lang[..pos];
-            if let Some(c) = &mut cskvp {
+            let code_block_cskvp_range = self.diagnostics.first_line(&range);
+            if let Some((c, cskvp_range)) = &mut cskvp {
                 // TODO: error
-                println!("Code has both prefix and inline style labels / config, ignoring both");
+                self.diagnostics
+                    .error("Code has both prefix and inline style labels / config")
+                    .with_section(&code_block_cskvp_range, "config specified here")
+                    .with_section(cskvp_range, "but config also specified here")
+                    .emit();
+                self.diagnostics.note("ignoring both").emit();
                 c.clear();
             } else {
                 let cskvp = Cskvp::new(Cow::Borrowed(&lang[pos + 1..]));
                 // check for figure and handle it
                 self.handle_cskvp(
                     cskvp,
+                    code_block_cskvp_range,
                     CmarkEvent::Start(CmarkTag::CodeBlock(Cow::Borrowed(language))),
+                    range,
                 );
                 return;
             }
@@ -328,7 +337,7 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
             language = lang;
         }
 
-        let mut cskvp = cskvp.unwrap_or_default();
+        let mut cskvp = cskvp.map(_0).unwrap_or_default();
         let tag = match language {
             "equation" | "$$" => {
                 Tag::Equation(Equation { label: cskvp.take_label(), caption: cskvp.take_caption() })
@@ -349,17 +358,18 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
             },
             "inlinelatex" => {
                 // code is just a single block of text
-                let latex = match self.parser.next().unwrap() {
+                let (evt, latex_range) = self.parser.next().unwrap();
+                let latex = match evt {
                     CmarkEvent::Text(text) => text,
                     _ => unreachable!(),
                 };
                 // consume end tag
-                match self.parser.next().unwrap() {
+                match self.parser.next().unwrap().0 {
                     CmarkEvent::End(CmarkTag::CodeBlock(_)) => (),
                     _ => unreachable!(),
                 }
 
-                self.buffer.push_back(Event::Latex(latex));
+                self.buffer.push_back((Event::Latex(latex), latex_range));
                 return;
             },
             _ => {
@@ -379,20 +389,20 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
             },
         };
 
-        self.buffer.push_back(Event::Start(tag.clone()));
+        self.buffer.push_back((Event::Start(tag.clone()), range.clone()));
         self.convert_until_end_inclusive(
             |t| if let CmarkTag::CodeBlock(_) = t { true } else { false },
         );
-        self.buffer.push_back(Event::End(tag));
+        self.buffer.push_back((Event::End(tag), range));
     }
 
-    fn convert_paragraph(&mut self) {
+    fn convert_paragraph(&mut self, range: Range<usize>) {
         // check for label/config (Start(Paragraph), Text("{#foo,config...}"),
         // End(Paragraph)/SoftBreak)
 
         macro_rules! handle_normal {
             () => {{
-                self.buffer.push_back(Event::Start(Tag::Paragraph));
+                self.buffer.push_back((Event::Start(Tag::Paragraph), range.clone()));
                 self.convert_until_end_inclusive(|t| {
                     if let CmarkTag::Paragraph = t {
                         true
@@ -400,12 +410,12 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
                         false
                     }
                 });
-                self.buffer.push_back(Event::End(Tag::Paragraph));
+                self.buffer.push_back((Event::End(Tag::Paragraph), range));
                 return;
             }};
         };
 
-        let text = match self.parser.peek() {
+        let text = match self.parser.peek().map(_0) {
             Some(CmarkEvent::Text(text)) => text, // continue
             _ => handle_normal!(),
         };
@@ -415,21 +425,22 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
             handle_normal!();
         }
         // consume text
-        let mut text = match self.parser.next().unwrap() {
+        let (evt, text_range) = self.parser.next().unwrap();
+        let mut text = match evt {
             CmarkEvent::Text(text) => text,
             _ => unreachable!(),
         };
 
         // TODO: look ahead further to enable Start(Paragraph), Label, End(Paragraph),
         // Start(Paragraph), Image, …
-        let end_paragraph = match self.parser.peek() {
+        let end_paragraph = match self.parser.peek().map(_0) {
             Some(CmarkEvent::End(CmarkTag::Paragraph)) => true,
             Some(CmarkEvent::SoftBreak) => false,
             _ => {
                 println!("not a label: {:?}", text);
                 // not a label, reset our look-ahead and generate original
-                self.buffer.push_back(Event::Start(Tag::Paragraph));
-                self.buffer.push_back(Event::Text(text));
+                self.buffer.push_back((Event::Start(Tag::Paragraph), range.clone()));
+                self.buffer.push_back((Event::Text(text), text_range));
                 self.convert_until_end_inclusive(|t| {
                     if let CmarkTag::Paragraph = t {
                         true
@@ -437,7 +448,7 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
                         false
                     }
                 });
-                self.buffer.push_back(Event::End(Tag::Paragraph));
+                self.buffer.push_back((Event::End(Tag::Paragraph), range));
                 return;
             },
         };
@@ -448,22 +459,23 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
         // if it's a label at the beginning of a paragraph, create that paragraph before creating
         // the element
         if !end_paragraph {
-            self.buffer.push_back(Event::Start(Tag::Paragraph));
+            self.buffer.push_back((Event::Start(Tag::Paragraph), range.clone()));
         }
 
         // parse label
         text.truncate_end(1);
         text.truncate_start(1);
         let mut cskvp = Cskvp::new(text);
+        let cskvp_range = Range { start: text_range.start + 1, end: text_range.end - 1 };
         // if next element could have a label, convert that element with the label
         // otherwise create label event
-        match self.parser.peek() {
+        match self.parser.peek().map(_0) {
             Some(CmarkEvent::Start(CmarkTag::Header(_)))
             | Some(CmarkEvent::Start(CmarkTag::CodeBlock(_)))
             | Some(CmarkEvent::Start(CmarkTag::Table(_)))
             | Some(CmarkEvent::Start(CmarkTag::Image(..))) => {
-                let next_element = self.parser.next().unwrap();
-                self.handle_cskvp(cskvp, next_element)
+                let (next_element, next_range) = self.parser.next().unwrap();
+                self.handle_cskvp(cskvp, cskvp_range, next_element, next_range)
             },
             _ => {
                 if !cskvp.has_label() {
@@ -473,7 +485,7 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
                         cskvp
                     );
                 }
-                self.buffer.push_back(Event::Label(cskvp.take_label().unwrap()));
+                self.buffer.push_back((Event::Label(cskvp.take_label().unwrap()), text_range));
             },
         }
 
@@ -485,11 +497,14 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
                     false
                 }
             });
-            self.buffer.push_back(Event::End(Tag::Paragraph));
+            self.buffer.push_back((Event::End(Tag::Paragraph), range));
         }
     }
 
-    fn handle_cskvp(&mut self, mut cskvp: Cskvp<'a>, next_element: CmarkEvent<'a>) {
+    fn handle_cskvp(
+        &mut self, mut cskvp: Cskvp<'a>, cskvp_range: Range<usize>,
+        next_element: CmarkEvent<'a>, next_range: Range<usize>
+    ) {
         // check if we want a figure
         let figure = match cskvp.take_figure().unwrap_or(self.cfg.figures) {
             false => None,
@@ -505,30 +520,32 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
             },
         };
         if let Some(figure) = figure.clone() {
-            self.buffer.push_back(Event::Start(figure));
+            self.buffer.push_back((Event::Start(figure), next_range.clone()));
         }
 
         match next_element {
-            CmarkEvent::Start(CmarkTag::Header(label)) => self.convert_header(label, Some(cskvp)),
+            CmarkEvent::Start(CmarkTag::Header(label)) => {
+                self.convert_header(label, next_range.clone(), Some((cskvp, cskvp_range)))
+            },
             CmarkEvent::Start(CmarkTag::CodeBlock(lang)) => {
-                self.convert_code_block(lang, Some(cskvp))
+                self.convert_code_block(lang, next_range.clone(), Some((cskvp, cskvp_range)))
             },
             CmarkEvent::Start(CmarkTag::Table(alignment)) => {
-                self.convert_table(alignment, Some(cskvp))
+                self.convert_table(alignment, next_range.clone(), Some((cskvp, cskvp_range)))
             },
             CmarkEvent::Start(CmarkTag::Image(typ, dst, title)) => {
-                self.convert_image(typ, dst, title, Some(cskvp))
+                self.convert_image(typ, dst, title, next_range.clone(), Some((cskvp, cskvp_range)))
             },
             element => panic!("handle_cskvp called with unknown element {:?}", element),
         }
 
         if let Some(figure) = figure {
-            self.buffer.push_back(Event::End(figure));
+            self.buffer.push_back((Event::End(figure), next_range));
         }
     }
 
-    fn convert_header(&mut self, level: i32, cskvp: Option<Cskvp<'a>>) {
-        let mut cskvp = cskvp.unwrap_or_default();
+    fn convert_header(&mut self, level: i32, range: Range<usize>, cskvp: Option<(Cskvp<'a>, Range<usize>)>) {
+        let mut cskvp = cskvp.map(_0).unwrap_or_default();
         // header can have 3 different labels:
         // • `{#foo}\n\n# Header`: "prefix" style
         // • `# Header {#foo}: "inline" style
@@ -574,23 +591,23 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
         };
 
         let tag = Tag::Header(Header { label, level });
-        self.buffer.insert(current_index, Event::Start(tag.clone()));
-        self.buffer.push_back(Event::End(tag));
+        self.buffer.insert(current_index, (Event::Start(tag.clone()), range.clone()));
+        self.buffer.push_back((Event::End(tag), range));
     }
 
-    fn convert_table(&mut self, alignment: Vec<Alignment>, cskvp: Option<Cskvp<'a>>) {
-        let mut cskvp = cskvp.unwrap_or_default();
+    fn convert_table(&mut self, alignment: Vec<Alignment>, range: Range<usize>, cskvp: Option<(Cskvp<'a>, Range<usize>)>) {
+        let mut cskvp = cskvp.map(_0).unwrap_or_default();
         let tag = Tag::Table(Table {
             label: cskvp.take_label(),
             caption: cskvp.take_caption(),
             alignment,
         });
-        self.buffer.push_back(Event::Start(tag.clone()));
+        self.buffer.push_back((Event::Start(tag.clone()), range.clone()));
         self.convert_until_end_inclusive(|t| if let CmarkTag::Table(_) = t { true } else { false });
-        self.buffer.push_back(Event::End(tag));
+        self.buffer.push_back((Event::End(tag), range));
     }
 
-    fn convert_link(&mut self, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>) {
+    fn convert_link(&mut self, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>, range: Range<usize>) {
         let evt = match refs::parse_references(self.cfg, typ, dst, title) {
             ReferenceParseResult::BiberReferences(biber) => Event::BiberReferences(biber),
             ReferenceParseResult::InterLink(interlink) => Event::InterLink(interlink),
@@ -607,7 +624,7 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
         };
         match evt {
             Event::Start(tag) => {
-                self.buffer.push_back(Event::Start(tag.clone()));
+                self.buffer.push_back((Event::Start(tag.clone()), range.clone()));
                 self.convert_until_end_inclusive(|t| {
                     if let CmarkTag::Link(..) = t {
                         true
@@ -615,17 +632,18 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
                         false
                     }
                 });
-                self.buffer.push_back(Event::End(tag));
+                self.buffer.push_back((Event::End(tag), range));
             },
             evt => {
-                self.buffer.push_back(evt);
+                self.buffer.push_back((evt, range));
                 self.consume_until_end_inclusive();
             },
         }
     }
 
     fn convert_image(
-        &mut self, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>, cskvp: Option<Cskvp<'a>>,
+        &mut self, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>, range: Range<usize>,
+        cskvp: Option<(Cskvp<'a>, Range<usize>)>,
     ) {
         // TODO: maybe not concat all text-like events but actually forward events
         // The CommonMark spec says that the parser should produce the correct events, while
@@ -641,8 +659,8 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
             | LinkType::ShortcutUnknown => None,
             LinkType::Autolink | LinkType::Email => unreachable!("{:?} can be images???", typ),
         };
-        let mut cskvp = cskvp.unwrap_or_default();
-        self.buffer.push_back(Event::Include(Include {
+        let mut cskvp = cskvp.map(_0).unwrap_or_default();
+        self.buffer.push_back((Event::Include(Include {
             label: cskvp.take_label(),
             caption: cskvp.take_caption(),
             title: if title.is_empty() { None } else { Some(title) },
@@ -651,6 +669,29 @@ impl<'a, B: Backend<'a>> Frontend<'a, B> {
             scale: cskvp.take_double("scale"),
             width: cskvp.take_double("width"),
             height: cskvp.take_double("height"),
-        }))
+        }), range))
     }
+}
+
+trait Get0 {
+    type Output;
+    fn get_0(self) -> Self::Output;
+}
+
+impl<A, B> Get0 for (A, B) {
+    type Output = A;
+    fn get_0(self) -> Self::Output {
+        self.0
+    }
+}
+
+impl<'a, A, B> Get0 for &'a (A, B) {
+    type Output = &'a A;
+    fn get_0(self) -> Self::Output {
+        &self.0
+    }
+}
+
+fn _0<T: Get0>(t: T) -> T::Output {
+    t.get_0()
 }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -19,7 +19,6 @@ pub use self::refs::LinkType;
 use self::concat::Concat;
 use self::convert_cow::{ConvertCow, Event as CmarkEvent, Tag as CmarkTag};
 use self::refs::ReferenceParseResult;
-use crate::backend::Backend;
 use crate::config::Config;
 use crate::cskvp::Cskvp;
 use crate::diagnostics::Diagnostics;

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::iter::Peekable;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use lazy_static::lazy_static;
 use pulldown_cmark::{Options as CmarkOptions, Parser as CmarkParser};
@@ -28,7 +29,7 @@ use crate::resolve::Command;
 
 pub struct Frontend<'a> {
     cfg: &'a Config,
-    diagnostics: Diagnostics<'a>,
+    diagnostics: Arc<Diagnostics<'a>>,
     parser: Peekable<Concat<'a>>,
     buffer: VecDeque<WithRange<Event<'a>>>,
 }
@@ -62,7 +63,7 @@ fn broken_link_callback(normalized_ref: &str, text_ref: &str) -> Option<(String,
 }
 
 impl<'a> Frontend<'a> {
-    pub fn new(cfg: &'a Config, markdown: &'a str, diagnostics: Diagnostics<'a>) -> Frontend<'a> {
+    pub fn new(cfg: &'a Config, markdown: &'a str, diagnostics: Arc<Diagnostics<'a>>) -> Frontend<'a> {
         let parser = CmarkParser::new_with_broken_link_callback(
             markdown,
             CmarkOptions::ENABLE_FOOTNOTES
@@ -336,7 +337,7 @@ impl<'a> Frontend<'a> {
                 Cow::Borrowed(&lang[pos + 1..]),
                 code_block_cskvp_range,
                 code_block_cskvp_content_range,
-                self.diagnostics.clone(),
+                Arc::clone(&self.diagnostics),
             );
             if let Some(c) = &mut cskvp {
                 self.diagnostics

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -441,7 +441,6 @@ impl<'a> Frontend<'a> {
             Some(CmarkEvent::End(CmarkTag::Paragraph)) => true,
             Some(CmarkEvent::SoftBreak) => false,
             _ => {
-                println!("not a label: {:?}", text);
                 // not a label, reset our look-ahead and generate original
                 self.buffer.push_back((Event::Start(Tag::Paragraph), range.clone()));
                 self.buffer.push_back((Event::Text(text), text_range));
@@ -624,7 +623,7 @@ impl<'a> Frontend<'a> {
     }
 
     fn convert_link(&mut self, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>, range: Range<usize>) {
-        let evt = match refs::parse_references(self.cfg, typ, dst, title) {
+        let evt = match refs::parse_references(self.cfg, typ, dst, title, range.clone(), &mut self.diagnostics) {
             ReferenceParseResult::BiberReferences(biber) => Event::BiberReferences(biber),
             ReferenceParseResult::InterLink(interlink) => Event::InterLink(interlink),
             ReferenceParseResult::Url(url) => Event::Url(url),

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -209,7 +209,7 @@ impl<'a> Frontend<'a> {
             if let Some(range) = &mut range {
                 range.end = evt_range.end;
             } else {
-                range = Some(evt_range.clone());
+                range = Some(evt_range);
             }
             match &evt {
                 CmarkEvent::End(ref tag) if f(tag) => return (text, range),
@@ -334,7 +334,7 @@ impl<'a> Frontend<'a> {
             };
             let inline_cskvp = Cskvp::new(
                 Cow::Borrowed(&lang[pos + 1..]),
-                code_block_cskvp_range.clone(),
+                code_block_cskvp_range,
                 code_block_cskvp_content_range,
                 self.diagnostics.clone(),
             );
@@ -413,7 +413,7 @@ impl<'a> Frontend<'a> {
             }),
         };
 
-        self.buffer.push_back(WithRange(Event::Start(tag.clone()), range.clone()));
+        self.buffer.push_back(WithRange(Event::Start(tag.clone()), range));
         self.convert_until_end_inclusive(
             |t| if let CmarkTag::CodeBlock(_) = t { true } else { false },
         );
@@ -426,7 +426,7 @@ impl<'a> Frontend<'a> {
 
         macro_rules! handle_normal {
             () => {{
-                self.buffer.push_back(WithRange(Event::Start(Tag::Paragraph), range.clone()));
+                self.buffer.push_back(WithRange(Event::Start(Tag::Paragraph), range));
                 self.convert_until_end_inclusive(|t| {
                     if let CmarkTag::Paragraph = t {
                         true
@@ -675,7 +675,7 @@ impl<'a> Frontend<'a> {
         };
         match evt {
             Event::Start(tag) => {
-                self.buffer.push_back(WithRange(Event::Start(tag.clone()), range.clone()));
+                self.buffer.push_back(WithRange(Event::Start(tag.clone()), range));
                 self.convert_until_end_inclusive(|t| {
                     if let CmarkTag::Link(..) = t {
                         true

--- a/src/frontend/range.rs
+++ b/src/frontend/range.rs
@@ -1,0 +1,35 @@
+use std::ops::Range;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl From<Range<usize>> for SourceRange {
+    fn from(Range { start, end }: Range<usize>) -> Self {
+        SourceRange { start, end }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WithRange<T>(pub T, pub SourceRange);
+
+impl<T> WithRange<T> {
+    pub fn element(self) -> T {
+        self.0
+    }
+
+    pub fn range(&self) -> SourceRange {
+        self.1
+    }
+
+    pub fn as_ref(&self) -> WithRange<&T> {
+        WithRange(&self.0, self.1)
+    }
+
+    pub fn map<R>(self, f: impl FnOnce(T) -> R) -> WithRange<R> {
+        let WithRange(element, range) = self;
+        WithRange(f(element), range)
+    }
+}

--- a/src/frontend/refs.rs
+++ b/src/frontend/refs.rs
@@ -1,14 +1,14 @@
 use std::borrow::Cow;
-use std::str::FromStr;
 use std::ops::Range;
+use std::str::FromStr;
 
 pub use pulldown_cmark::LinkType;
 
 use super::event::{BiberReference, InterLink, Url};
 use crate::config::Config;
+use crate::diagnostics::Diagnostics;
 use crate::ext::{CowExt, StrExt};
 use crate::resolve::Command;
-use crate::diagnostics::Diagnostics;
 
 #[derive(Debug)]
 pub enum ReferenceParseResult<'a> {
@@ -23,8 +23,8 @@ pub enum ReferenceParseResult<'a> {
 }
 
 pub fn parse_references<'a>(
-    cfg: &'a Config, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>,
-    range: Range<usize>, diagnostics: &mut Diagnostics<'a>,
+    cfg: &'a Config, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>, range: Range<usize>,
+    diagnostics: &mut Diagnostics<'a>,
 ) -> ReferenceParseResult<'a> {
     // ShortcutUnknown and ReferenceUnknown make destination lowercase, but save original case in
     // title

--- a/src/frontend/refs.rs
+++ b/src/frontend/refs.rs
@@ -51,7 +51,7 @@ pub fn parse_references<'a>(
         if cfg.bibliography.is_none() {
             diagnostics
                 .error("found biber reference, but no bibliography file found")
-                .with_section(&range, "referenced here")
+                .with_error_section(&range, "referenced here")
                 .note("rendering as text")
                 .emit();
             return ReferenceParseResult::Text(Cow::Owned(format!("[{}]", dst)));

--- a/src/frontend/refs.rs
+++ b/src/frontend/refs.rs
@@ -24,7 +24,7 @@ pub enum ReferenceParseResult<'a> {
 
 pub fn parse_references<'a>(
     cfg: &'a Config, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>, range: SourceRange,
-    diagnostics: &mut Diagnostics<'a>,
+    diagnostics: &Diagnostics<'a>,
 ) -> ReferenceParseResult<'a> {
     // ShortcutUnknown and ReferenceUnknown make destination lowercase, but save original case in
     // title

--- a/src/frontend/refs.rs
+++ b/src/frontend/refs.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::ops::Range;
 use std::str::FromStr;
 
 pub use pulldown_cmark::LinkType;
@@ -8,6 +7,7 @@ use super::event::{BiberReference, InterLink, Url};
 use crate::config::Config;
 use crate::diagnostics::Diagnostics;
 use crate::ext::{CowExt, StrExt};
+use crate::frontend::range::SourceRange;
 use crate::resolve::Command;
 
 #[derive(Debug)]
@@ -23,7 +23,7 @@ pub enum ReferenceParseResult<'a> {
 }
 
 pub fn parse_references<'a>(
-    cfg: &'a Config, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>, range: Range<usize>,
+    cfg: &'a Config, typ: LinkType, dst: Cow<'a, str>, title: Cow<'a, str>, range: SourceRange,
     diagnostics: &mut Diagnostics<'a>,
 ) -> ReferenceParseResult<'a> {
     // ShortcutUnknown and ReferenceUnknown make destination lowercase, but save original case in
@@ -51,7 +51,7 @@ pub fn parse_references<'a>(
         if cfg.bibliography.is_none() {
             diagnostics
                 .error("found biber reference, but no bibliography file found")
-                .with_error_section(&range, "referenced here")
+                .with_error_section(range, "referenced here")
                 .note("rendering as text")
                 .emit();
             return ReferenceParseResult::Text(Cow::Owned(format!("[{}]", dst)));

--- a/src/generator/code_gen_units.rs
+++ b/src/generator/code_gen_units.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
-use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::diagnostics::Diagnostics;
 use crate::error::Result;
+use crate::frontend::range::WithRange;
 use crate::generator::event::{Event, Tag};
 use crate::generator::{Generator, Stack};
 use crate::resolve::Context;
@@ -42,133 +42,136 @@ pub enum StackElement<'a, D: Backend<'a>> {
     Context(Context, Diagnostics<'a>),
 }
 
+use self::StackElement::*;
+
 #[rustfmt::skip]
 impl<'a, D: Backend<'a>> StackElement<'a, D> {
-    pub fn new(cfg: &'a Config, tag: Tag<'a>, range: Range<usize>, gen: &mut Generator<'a, D, impl Write>) -> Result<Self> {
+    pub fn new(cfg: &'a Config, tag: WithRange<Tag<'a>>, gen: &mut Generator<'a, D, impl Write>) -> Result<Self> {
+        let WithRange(tag, range) = tag;
         match tag {
-            Tag::Paragraph => Ok(StackElement::Paragraph(D::Paragraph::new(cfg, (), range, gen)?)),
-            Tag::Rule => Ok(StackElement::Rule(D::Rule::new(cfg, (), range, gen)?)),
-            Tag::Header(header) => Ok(StackElement::Header(D::Header::new(cfg, header, range, gen)?)),
-            Tag::BlockQuote => Ok(StackElement::BlockQuote(D::BlockQuote::new(cfg, (), range, gen)?)),
-            Tag::CodeBlock(cb) => Ok(StackElement::CodeBlock(D::CodeBlock::new(cfg, cb, range, gen)?)),
-            Tag::List => Ok(StackElement::List(D::List::new(cfg, (), range, gen)?)),
-            Tag::Enumerate(enumerate) => Ok(StackElement::Enumerate(D::Enumerate::new(cfg, enumerate, range, gen)?)),
-            Tag::Item => Ok(StackElement::Item(D::Item::new(cfg, (), range, gen)?)),
-            Tag::FootnoteDefinition(fnote) => Ok(StackElement::FootnoteDefinition(D::FootnoteDefinition::new(cfg, fnote, range, gen)?)),
-            Tag::Url(url) => Ok(StackElement::Url(D::UrlWithContent::new(cfg, url, range, gen)?)),
-            Tag::InterLink(interlink) => Ok(StackElement::InterLink(D::InterLinkWithContent::new(cfg, interlink, range, gen)?)),
-            Tag::HtmlBlock => Ok(StackElement::HtmlBlock(D::HtmlBlock::new(cfg, (), range, gen)?)),
-            Tag::Figure(figure) => Ok(StackElement::Figure(D::Figure::new(cfg, figure, range, gen)?)),
-            Tag::TableFigure(figure) => Ok(StackElement::TableFigure(D::TableFigure::new(cfg, figure, range, gen)?)),
-            Tag::Table(table) => Ok(StackElement::Table(D::Table::new(cfg, table, range, gen)?)),
-            Tag::TableHead => Ok(StackElement::TableHead(D::TableHead::new(cfg, (), range, gen)?)),
-            Tag::TableRow => Ok(StackElement::TableRow(D::TableRow::new(cfg, (), range, gen)?)),
-            Tag::TableCell => Ok(StackElement::TableCell(D::TableCell::new(cfg, (), range, gen)?)),
-            Tag::InlineEmphasis => Ok(StackElement::InlineEmphasis(D::InlineEmphasis::new(cfg, (), range, gen)?)),
-            Tag::InlineStrong => Ok(StackElement::InlineStrong(D::InlineStrong::new(cfg, (), range, gen)?)),
-            Tag::InlineStrikethrough => Ok(StackElement::InlineStrikethrough(D::InlineStrikethrough::new(cfg, (), range, gen)?)),
-            Tag::InlineCode => Ok(StackElement::InlineCode(D::InlineCode::new(cfg, (), range, gen)?)),
-            Tag::InlineMath => Ok(StackElement::InlineMath(D::InlineMath::new(cfg, (), range, gen)?)),
-            Tag::Equation(equation) => Ok(StackElement::Equation(D::Equation::new(cfg, equation, range, gen)?)),
-            Tag::NumberedEquation(equation) => Ok(StackElement::NumberedEquation(D::NumberedEquation::new(cfg, equation, range, gen)?)),
-            Tag::Graphviz(graphviz) => Ok(StackElement::Graphviz(D::Graphviz::new(cfg, graphviz, range, gen)?)),
+            Tag::Paragraph => Ok(Paragraph(D::Paragraph::new(cfg, WithRange((), range), gen)?)),
+            Tag::Rule => Ok(Rule(D::Rule::new(cfg, WithRange((), range), gen)?)),
+            Tag::Header(header) => Ok(Header(D::Header::new(cfg, WithRange(header, range), gen)?)),
+            Tag::BlockQuote => Ok(BlockQuote(D::BlockQuote::new(cfg, WithRange((), range), gen)?)),
+            Tag::CodeBlock(cb) => Ok(CodeBlock(D::CodeBlock::new(cfg, WithRange(cb, range), gen)?)),
+            Tag::List => Ok(List(D::List::new(cfg, WithRange((), range), gen)?)),
+            Tag::Enumerate(enumerate) => Ok(Enumerate(D::Enumerate::new(cfg, WithRange(enumerate, range), gen)?)),
+            Tag::Item => Ok(Item(D::Item::new(cfg, WithRange((), range), gen)?)),
+            Tag::FootnoteDefinition(fnote) => Ok(FootnoteDefinition(D::FootnoteDefinition::new(cfg, WithRange(fnote, range), gen)?)),
+            Tag::Url(url) => Ok(Url(D::UrlWithContent::new(cfg, WithRange(url, range), gen)?)),
+            Tag::InterLink(interlink) => Ok(InterLink(D::InterLinkWithContent::new(cfg, WithRange(interlink, range), gen)?)),
+            Tag::HtmlBlock => Ok(HtmlBlock(D::HtmlBlock::new(cfg, WithRange((), range), gen)?)),
+            Tag::Figure(figure) => Ok(Figure(D::Figure::new(cfg, WithRange(figure, range), gen)?)),
+            Tag::TableFigure(figure) => Ok(TableFigure(D::TableFigure::new(cfg, WithRange(figure, range), gen)?)),
+            Tag::Table(table) => Ok(Table(D::Table::new(cfg, WithRange(table, range), gen)?)),
+            Tag::TableHead => Ok(TableHead(D::TableHead::new(cfg, WithRange((), range), gen)?)),
+            Tag::TableRow => Ok(TableRow(D::TableRow::new(cfg, WithRange((), range), gen)?)),
+            Tag::TableCell => Ok(TableCell(D::TableCell::new(cfg, WithRange((), range), gen)?)),
+            Tag::InlineEmphasis => Ok(InlineEmphasis(D::InlineEmphasis::new(cfg, WithRange((), range), gen)?)),
+            Tag::InlineStrong => Ok(InlineStrong(D::InlineStrong::new(cfg, WithRange((), range), gen)?)),
+            Tag::InlineStrikethrough => Ok(InlineStrikethrough(D::InlineStrikethrough::new(cfg, WithRange((), range), gen)?)),
+            Tag::InlineCode => Ok(InlineCode(D::InlineCode::new(cfg, WithRange((), range), gen)?)),
+            Tag::InlineMath => Ok(InlineMath(D::InlineMath::new(cfg, WithRange((), range), gen)?)),
+            Tag::Equation(equation) => Ok(Equation(D::Equation::new(cfg, WithRange(equation, range), gen)?)),
+            Tag::NumberedEquation(equation) => Ok(NumberedEquation(D::NumberedEquation::new(cfg, WithRange(equation, range), gen)?)),
+            Tag::Graphviz(graphviz) => Ok(Graphviz(D::Graphviz::new(cfg, WithRange(graphviz, range), gen)?)),
         }
     }
 
     pub fn output_redirect(&mut self) -> Option<&mut dyn Write> {
         match self {
-            StackElement::Paragraph(s) => s.output_redirect(),
-            StackElement::Rule(s) => s.output_redirect(),
-            StackElement::Header(s) => s.output_redirect(),
-            StackElement::BlockQuote(s) => s.output_redirect(),
-            StackElement::CodeBlock(s) => s.output_redirect(),
-            StackElement::List(s) => s.output_redirect(),
-            StackElement::Enumerate(s) => s.output_redirect(),
-            StackElement::Item(s) => s.output_redirect(),
-            StackElement::FootnoteDefinition(s) => s.output_redirect(),
-            StackElement::Url(s) => s.output_redirect(),
-            StackElement::InterLink(s) => s.output_redirect(),
-            StackElement::HtmlBlock(s) => s.output_redirect(),
-            StackElement::Figure(s) => s.output_redirect(),
-            StackElement::TableFigure(s) => s.output_redirect(),
-            StackElement::Table(s) => s.output_redirect(),
-            StackElement::TableHead(s) => s.output_redirect(),
-            StackElement::TableRow(s) => s.output_redirect(),
-            StackElement::TableCell(s) => s.output_redirect(),
-            StackElement::InlineEmphasis(s) => s.output_redirect(),
-            StackElement::InlineStrong(s) => s.output_redirect(),
-            StackElement::InlineStrikethrough(s) => s.output_redirect(),
-            StackElement::InlineCode(s) => s.output_redirect(),
-            StackElement::InlineMath(s) => s.output_redirect(),
-            StackElement::Equation(s) => s.output_redirect(),
-            StackElement::NumberedEquation(s) => s.output_redirect(),
-            StackElement::Graphviz(s) => s.output_redirect(),
+            Paragraph(s) => s.output_redirect(),
+            Rule(s) => s.output_redirect(),
+            Header(s) => s.output_redirect(),
+            BlockQuote(s) => s.output_redirect(),
+            CodeBlock(s) => s.output_redirect(),
+            List(s) => s.output_redirect(),
+            Enumerate(s) => s.output_redirect(),
+            Item(s) => s.output_redirect(),
+            FootnoteDefinition(s) => s.output_redirect(),
+            Url(s) => s.output_redirect(),
+            InterLink(s) => s.output_redirect(),
+            HtmlBlock(s) => s.output_redirect(),
+            Figure(s) => s.output_redirect(),
+            TableFigure(s) => s.output_redirect(),
+            Table(s) => s.output_redirect(),
+            TableHead(s) => s.output_redirect(),
+            TableRow(s) => s.output_redirect(),
+            TableCell(s) => s.output_redirect(),
+            InlineEmphasis(s) => s.output_redirect(),
+            InlineStrong(s) => s.output_redirect(),
+            InlineStrikethrough(s) => s.output_redirect(),
+            InlineCode(s) => s.output_redirect(),
+            InlineMath(s) => s.output_redirect(),
+            Equation(s) => s.output_redirect(),
+            NumberedEquation(s) => s.output_redirect(),
+            Graphviz(s) => s.output_redirect(),
 
-            StackElement::Context(..) => None,
+            Context(..) => None,
         }
     }
 
     pub fn intercept_event<'b>(&mut self, stack: &mut Stack<'a, 'b, impl Backend<'a>, impl Write>, e: Event<'a>) -> Result<Option<Event<'a>>> {
         match self {
-            StackElement::Paragraph(s) => s.intercept_event(stack, e),
-            StackElement::Rule(s) => s.intercept_event(stack, e),
-            StackElement::Header(s) => s.intercept_event(stack, e),
-            StackElement::BlockQuote(s) => s.intercept_event(stack, e),
-            StackElement::CodeBlock(s) => s.intercept_event(stack, e),
-            StackElement::List(s) => s.intercept_event(stack, e),
-            StackElement::Enumerate(s) => s.intercept_event(stack, e),
-            StackElement::Item(s) => s.intercept_event(stack, e),
-            StackElement::FootnoteDefinition(s) => s.intercept_event(stack, e),
-            StackElement::Url(s) => s.intercept_event(stack, e),
-            StackElement::InterLink(s) => s.intercept_event(stack, e),
-            StackElement::HtmlBlock(s) => s.intercept_event(stack, e),
-            StackElement::Figure(s) => s.intercept_event(stack, e),
-            StackElement::TableFigure(s) => s.intercept_event(stack, e),
-            StackElement::Table(s) => s.intercept_event(stack, e),
-            StackElement::TableHead(s) => s.intercept_event(stack, e),
-            StackElement::TableRow(s) => s.intercept_event(stack, e),
-            StackElement::TableCell(s) => s.intercept_event(stack, e),
-            StackElement::InlineEmphasis(s) => s.intercept_event(stack, e),
-            StackElement::InlineStrong(s) => s.intercept_event(stack, e),
-            StackElement::InlineStrikethrough(s) => s.intercept_event(stack, e),
-            StackElement::InlineCode(s) => s.intercept_event(stack, e),
-            StackElement::InlineMath(s) => s.intercept_event(stack, e),
-            StackElement::Equation(s) => s.intercept_event(stack, e),
-            StackElement::NumberedEquation(s) => s.intercept_event(stack, e),
-            StackElement::Graphviz(s) => s.intercept_event(stack, e),
+            Paragraph(s) => s.intercept_event(stack, e),
+            Rule(s) => s.intercept_event(stack, e),
+            Header(s) => s.intercept_event(stack, e),
+            BlockQuote(s) => s.intercept_event(stack, e),
+            CodeBlock(s) => s.intercept_event(stack, e),
+            List(s) => s.intercept_event(stack, e),
+            Enumerate(s) => s.intercept_event(stack, e),
+            Item(s) => s.intercept_event(stack, e),
+            FootnoteDefinition(s) => s.intercept_event(stack, e),
+            Url(s) => s.intercept_event(stack, e),
+            InterLink(s) => s.intercept_event(stack, e),
+            HtmlBlock(s) => s.intercept_event(stack, e),
+            Figure(s) => s.intercept_event(stack, e),
+            TableFigure(s) => s.intercept_event(stack, e),
+            Table(s) => s.intercept_event(stack, e),
+            TableHead(s) => s.intercept_event(stack, e),
+            TableRow(s) => s.intercept_event(stack, e),
+            TableCell(s) => s.intercept_event(stack, e),
+            InlineEmphasis(s) => s.intercept_event(stack, e),
+            InlineStrong(s) => s.intercept_event(stack, e),
+            InlineStrikethrough(s) => s.intercept_event(stack, e),
+            InlineCode(s) => s.intercept_event(stack, e),
+            InlineMath(s) => s.intercept_event(stack, e),
+            Equation(s) => s.intercept_event(stack, e),
+            NumberedEquation(s) => s.intercept_event(stack, e),
+            Graphviz(s) => s.intercept_event(stack, e),
 
-            StackElement::Context(..) => Ok(Some(e)),
+            Context(..) => Ok(Some(e)),
         }
     }
 
-    pub fn finish<'b>(self, tag: Tag<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, peek: Option<(&Event<'a>, Range<usize>)>) -> Result<()> {
+    pub fn finish<'b>(self, tag: Tag<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, peek: Option<WithRange<&Event<'a>>>) -> Result<()> {
         match (self, tag) {
-            (StackElement::Paragraph(s), Tag::Paragraph) => s.finish(gen, peek),
-            (StackElement::Rule(s), Tag::Rule) => s.finish(gen, peek),
-            (StackElement::Header(s), Tag::Header(_)) => s.finish(gen, peek),
-            (StackElement::BlockQuote(s), Tag::BlockQuote) => s.finish(gen, peek),
-            (StackElement::CodeBlock(s), Tag::CodeBlock(_)) => s.finish(gen, peek),
-            (StackElement::List(s), Tag::List) => s.finish(gen, peek),
-            (StackElement::Enumerate(s), Tag::Enumerate(_)) => s.finish(gen, peek),
-            (StackElement::Item(s), Tag::Item) => s.finish(gen, peek),
-            (StackElement::FootnoteDefinition(s), Tag::FootnoteDefinition(_)) => s.finish(gen, peek),
-            (StackElement::Url(s), Tag::Url(_)) => s.finish(gen, peek),
-            (StackElement::InterLink(s), Tag::InterLink(_)) => s.finish(gen, peek),
-            (StackElement::HtmlBlock(s), Tag::HtmlBlock) => s.finish(gen, peek),
-            (StackElement::Figure(s), Tag::Figure(_)) => s.finish(gen, peek),
-            (StackElement::TableFigure(s), Tag::TableFigure(_)) => s.finish(gen, peek),
-            (StackElement::Table(s), Tag::Table(_)) => s.finish(gen, peek),
-            (StackElement::TableHead(s), Tag::TableHead) => s.finish(gen, peek),
-            (StackElement::TableRow(s), Tag::TableRow) => s.finish(gen, peek),
-            (StackElement::TableCell(s), Tag::TableCell) => s.finish(gen, peek),
-            (StackElement::InlineEmphasis(s), Tag::InlineEmphasis) => s.finish(gen, peek),
-            (StackElement::InlineStrong(s), Tag::InlineStrong) => s.finish(gen, peek),
-            (StackElement::InlineStrikethrough(s), Tag::InlineStrikethrough) => s.finish(gen, peek),
-            (StackElement::InlineCode(s), Tag::InlineCode) => s.finish(gen, peek),
-            (StackElement::InlineMath(s), Tag::InlineMath) => s.finish(gen, peek),
-            (StackElement::Equation(s), Tag::Equation(_)) => s.finish(gen, peek),
-            (StackElement::NumberedEquation(s), Tag::NumberedEquation(_)) => s.finish(gen, peek),
-            (StackElement::Graphviz(s), Tag::Graphviz(_)) => s.finish(gen, peek),
+            (Paragraph(s), Tag::Paragraph) => s.finish(gen, peek),
+            (Rule(s), Tag::Rule) => s.finish(gen, peek),
+            (Header(s), Tag::Header(_)) => s.finish(gen, peek),
+            (BlockQuote(s), Tag::BlockQuote) => s.finish(gen, peek),
+            (CodeBlock(s), Tag::CodeBlock(_)) => s.finish(gen, peek),
+            (List(s), Tag::List) => s.finish(gen, peek),
+            (Enumerate(s), Tag::Enumerate(_)) => s.finish(gen, peek),
+            (Item(s), Tag::Item) => s.finish(gen, peek),
+            (FootnoteDefinition(s), Tag::FootnoteDefinition(_)) => s.finish(gen, peek),
+            (Url(s), Tag::Url(_)) => s.finish(gen, peek),
+            (InterLink(s), Tag::InterLink(_)) => s.finish(gen, peek),
+            (HtmlBlock(s), Tag::HtmlBlock) => s.finish(gen, peek),
+            (Figure(s), Tag::Figure(_)) => s.finish(gen, peek),
+            (TableFigure(s), Tag::TableFigure(_)) => s.finish(gen, peek),
+            (Table(s), Tag::Table(_)) => s.finish(gen, peek),
+            (TableHead(s), Tag::TableHead) => s.finish(gen, peek),
+            (TableRow(s), Tag::TableRow) => s.finish(gen, peek),
+            (TableCell(s), Tag::TableCell) => s.finish(gen, peek),
+            (InlineEmphasis(s), Tag::InlineEmphasis) => s.finish(gen, peek),
+            (InlineStrong(s), Tag::InlineStrong) => s.finish(gen, peek),
+            (InlineStrikethrough(s), Tag::InlineStrikethrough) => s.finish(gen, peek),
+            (InlineCode(s), Tag::InlineCode) => s.finish(gen, peek),
+            (InlineMath(s), Tag::InlineMath) => s.finish(gen, peek),
+            (Equation(s), Tag::Equation(_)) => s.finish(gen, peek),
+            (NumberedEquation(s), Tag::NumberedEquation(_)) => s.finish(gen, peek),
+            (Graphviz(s), Tag::Graphviz(_)) => s.finish(gen, peek),
             (state, tag) => unreachable!("invalid end tag {:?}, expected {:?}", tag, state),
         }
     }
@@ -177,7 +180,7 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
     #[allow(dead_code)]
     pub fn is_graphviz(&self) -> bool {
         match self {
-            StackElement::Graphviz(_) => true,
+            Graphviz(_) => true,
             _ => false
         }
     }
@@ -185,7 +188,7 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
     #[allow(dead_code)]
     pub fn is_code_block(&self) -> bool {
         self.is_graphviz() || match self {
-            StackElement::CodeBlock(_) => true,
+            CodeBlock(_) => true,
             _ => false
         }
     }
@@ -193,28 +196,28 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
     #[allow(dead_code)]
     pub fn is_list(&self) -> bool {
         match self {
-            StackElement::List(_) => true,
+            List(_) => true,
             _ => false,
         }
     }
 
     pub fn is_enumerate(&self) -> bool {
         match self {
-            StackElement::Enumerate(_) => true,
+            Enumerate(_) => true,
             _ => false
         }
     }
 
     pub fn is_equation(&self) -> bool {
         match self {
-            StackElement::Equation(_) => true,
+            Equation(_) => true,
             _ => false,
         }
     }
 
     pub fn is_numbered_equation(&self) -> bool {
         match self {
-            StackElement::NumberedEquation(_) => true,
+            NumberedEquation(_) => true,
             _ => false,
         }
     }
@@ -237,7 +240,7 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
     #[allow(dead_code)]
     pub fn is_inline_emphasis(&self) -> bool {
         match self {
-            StackElement::InlineEmphasis(_) => true,
+            InlineEmphasis(_) => true,
             _ => false
         }
     }
@@ -245,7 +248,7 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
     #[allow(dead_code)]
     pub fn is_inline_strong(&self) -> bool {
         match self {
-            StackElement::InlineStrong(_) => true,
+            InlineStrong(_) => true,
             _ => false
         }
     }
@@ -253,7 +256,7 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
     #[allow(dead_code)]
     pub fn is_inline_code(&self) -> bool {
         match self {
-            StackElement::InlineCode(_) => true,
+            InlineCode(_) => true,
             _ => false
         }
     }
@@ -261,14 +264,14 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
     #[allow(dead_code)]
     pub fn is_inline_math(&self) -> bool {
         match self {
-            StackElement::InlineMath(_) => true,
+            InlineMath(_) => true,
             _ => false,
         }
     }
 
     pub fn is_table(&self) -> bool {
         match self {
-            StackElement::Table(_) => true,
+            Table(_) => true,
             _ => false
         }
     }

--- a/src/generator/code_gen_units.rs
+++ b/src/generator/code_gen_units.rs
@@ -1,4 +1,5 @@
-use std::io::{Result, Write};
+use std::io::Write;
+use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
@@ -6,6 +7,7 @@ use crate::generator::event::{Event, Tag};
 use crate::generator::{Generator, Stack};
 use crate::resolve::Context;
 use crate::diagnostics::Diagnostics;
+use crate::error::Result;
 
 #[derive(Debug)]
 pub enum StackElement<'a, D: Backend<'a>> {
@@ -42,34 +44,34 @@ pub enum StackElement<'a, D: Backend<'a>> {
 
 #[rustfmt::skip]
 impl<'a, D: Backend<'a>> StackElement<'a, D> {
-    pub fn new(cfg: &'a Config, tag: Tag<'a>, gen: &mut Generator<'a, D, impl Write>) -> Result<Self> {
+    pub fn new(cfg: &'a Config, tag: Tag<'a>, range: Range<usize>, gen: &mut Generator<'a, D, impl Write>) -> Result<Self> {
         match tag {
-            Tag::Paragraph => Ok(StackElement::Paragraph(D::Paragraph::new(cfg, (), gen)?)),
-            Tag::Rule => Ok(StackElement::Rule(D::Rule::new(cfg, (), gen)?)),
-            Tag::Header(header) => Ok(StackElement::Header(D::Header::new(cfg, header, gen)?)),
-            Tag::BlockQuote => Ok(StackElement::BlockQuote(D::BlockQuote::new(cfg, (), gen)?)),
-            Tag::CodeBlock(cb) => Ok(StackElement::CodeBlock(D::CodeBlock::new(cfg, cb, gen)?)),
-            Tag::List => Ok(StackElement::List(D::List::new(cfg, (), gen)?)),
-            Tag::Enumerate(enumerate) => Ok(StackElement::Enumerate(D::Enumerate::new(cfg, enumerate, gen)?)),
-            Tag::Item => Ok(StackElement::Item(D::Item::new(cfg, (), gen)?)),
-            Tag::FootnoteDefinition(fnote) => Ok(StackElement::FootnoteDefinition(D::FootnoteDefinition::new(cfg, fnote, gen)?)),
-            Tag::Url(url) => Ok(StackElement::Url(D::UrlWithContent::new(cfg, url, gen)?)),
-            Tag::InterLink(interlink) => Ok(StackElement::InterLink(D::InterLinkWithContent::new(cfg, interlink, gen)?)),
-            Tag::HtmlBlock => Ok(StackElement::HtmlBlock(D::HtmlBlock::new(cfg, (), gen)?)),
-            Tag::Figure(figure) => Ok(StackElement::Figure(D::Figure::new(cfg, figure, gen)?)),
-            Tag::TableFigure(figure) => Ok(StackElement::TableFigure(D::TableFigure::new(cfg, figure, gen)?)),
-            Tag::Table(table) => Ok(StackElement::Table(D::Table::new(cfg, table, gen)?)),
-            Tag::TableHead => Ok(StackElement::TableHead(D::TableHead::new(cfg, (), gen)?)),
-            Tag::TableRow => Ok(StackElement::TableRow(D::TableRow::new(cfg, (), gen)?)),
-            Tag::TableCell => Ok(StackElement::TableCell(D::TableCell::new(cfg, (), gen)?)),
-            Tag::InlineEmphasis => Ok(StackElement::InlineEmphasis(D::InlineEmphasis::new(cfg, (), gen)?)),
-            Tag::InlineStrong => Ok(StackElement::InlineStrong(D::InlineStrong::new(cfg, (), gen)?)),
-            Tag::InlineStrikethrough => Ok(StackElement::InlineStrikethrough(D::InlineStrikethrough::new(cfg, (), gen)?)),
-            Tag::InlineCode => Ok(StackElement::InlineCode(D::InlineCode::new(cfg, (), gen)?)),
-            Tag::InlineMath => Ok(StackElement::InlineMath(D::InlineMath::new(cfg, (), gen)?)),
-            Tag::Equation(equation) => Ok(StackElement::Equation(D::Equation::new(cfg, equation, gen)?)),
-            Tag::NumberedEquation(equation) => Ok(StackElement::NumberedEquation(D::NumberedEquation::new(cfg, equation, gen)?)),
-            Tag::Graphviz(graphviz) => Ok(StackElement::Graphviz(D::Graphviz::new(cfg, graphviz, gen)?)),
+            Tag::Paragraph => Ok(StackElement::Paragraph(D::Paragraph::new(cfg, (), range, gen)?)),
+            Tag::Rule => Ok(StackElement::Rule(D::Rule::new(cfg, (), range, gen)?)),
+            Tag::Header(header) => Ok(StackElement::Header(D::Header::new(cfg, header, range, gen)?)),
+            Tag::BlockQuote => Ok(StackElement::BlockQuote(D::BlockQuote::new(cfg, (), range, gen)?)),
+            Tag::CodeBlock(cb) => Ok(StackElement::CodeBlock(D::CodeBlock::new(cfg, cb, range, gen)?)),
+            Tag::List => Ok(StackElement::List(D::List::new(cfg, (), range, gen)?)),
+            Tag::Enumerate(enumerate) => Ok(StackElement::Enumerate(D::Enumerate::new(cfg, enumerate, range, gen)?)),
+            Tag::Item => Ok(StackElement::Item(D::Item::new(cfg, (), range, gen)?)),
+            Tag::FootnoteDefinition(fnote) => Ok(StackElement::FootnoteDefinition(D::FootnoteDefinition::new(cfg, fnote, range, gen)?)),
+            Tag::Url(url) => Ok(StackElement::Url(D::UrlWithContent::new(cfg, url, range, gen)?)),
+            Tag::InterLink(interlink) => Ok(StackElement::InterLink(D::InterLinkWithContent::new(cfg, interlink, range, gen)?)),
+            Tag::HtmlBlock => Ok(StackElement::HtmlBlock(D::HtmlBlock::new(cfg, (), range, gen)?)),
+            Tag::Figure(figure) => Ok(StackElement::Figure(D::Figure::new(cfg, figure, range, gen)?)),
+            Tag::TableFigure(figure) => Ok(StackElement::TableFigure(D::TableFigure::new(cfg, figure, range, gen)?)),
+            Tag::Table(table) => Ok(StackElement::Table(D::Table::new(cfg, table, range, gen)?)),
+            Tag::TableHead => Ok(StackElement::TableHead(D::TableHead::new(cfg, (), range, gen)?)),
+            Tag::TableRow => Ok(StackElement::TableRow(D::TableRow::new(cfg, (), range, gen)?)),
+            Tag::TableCell => Ok(StackElement::TableCell(D::TableCell::new(cfg, (), range, gen)?)),
+            Tag::InlineEmphasis => Ok(StackElement::InlineEmphasis(D::InlineEmphasis::new(cfg, (), range, gen)?)),
+            Tag::InlineStrong => Ok(StackElement::InlineStrong(D::InlineStrong::new(cfg, (), range, gen)?)),
+            Tag::InlineStrikethrough => Ok(StackElement::InlineStrikethrough(D::InlineStrikethrough::new(cfg, (), range, gen)?)),
+            Tag::InlineCode => Ok(StackElement::InlineCode(D::InlineCode::new(cfg, (), range, gen)?)),
+            Tag::InlineMath => Ok(StackElement::InlineMath(D::InlineMath::new(cfg, (), range, gen)?)),
+            Tag::Equation(equation) => Ok(StackElement::Equation(D::Equation::new(cfg, equation, range, gen)?)),
+            Tag::NumberedEquation(equation) => Ok(StackElement::NumberedEquation(D::NumberedEquation::new(cfg, equation, range, gen)?)),
+            Tag::Graphviz(graphviz) => Ok(StackElement::Graphviz(D::Graphviz::new(cfg, graphviz, range, gen)?)),
         }
     }
 
@@ -139,7 +141,7 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
         }
     }
 
-    pub fn finish<'b>(self, tag: Tag<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, peek: Option<&Event<'a>>) -> Result<()> {
+    pub fn finish<'b>(self, tag: Tag<'a>, gen: &mut Generator<'a, impl Backend<'a>, impl Write>, peek: Option<(&Event<'a>, Range<usize>)>) -> Result<()> {
         match (self, tag) {
             (StackElement::Paragraph(s), Tag::Paragraph) => s.finish(gen, peek),
             (StackElement::Rule(s), Tag::Rule) => s.finish(gen, peek),

--- a/src/generator/code_gen_units.rs
+++ b/src/generator/code_gen_units.rs
@@ -3,11 +3,11 @@ use std::ops::Range;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
+use crate::diagnostics::Diagnostics;
+use crate::error::Result;
 use crate::generator::event::{Event, Tag};
 use crate::generator::{Generator, Stack};
 use crate::resolve::Context;
-use crate::diagnostics::Diagnostics;
-use crate::error::Result;
 
 #[derive(Debug)]
 pub enum StackElement<'a, D: Backend<'a>> {

--- a/src/generator/code_gen_units.rs
+++ b/src/generator/code_gen_units.rs
@@ -1,13 +1,11 @@
 use std::io::{Result, Write};
-use std::sync::Arc;
-
-use codespan::FileMap;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
 use crate::generator::event::{Event, Tag};
 use crate::generator::{Generator, Stack};
 use crate::resolve::Context;
+use crate::diagnostics::Diagnostics;
 
 #[derive(Debug)]
 pub enum StackElement<'a, D: Backend<'a>> {
@@ -39,7 +37,7 @@ pub enum StackElement<'a, D: Backend<'a>> {
     Graphviz(D::Graphviz),
 
     // resolve context
-    Context(Context, Arc<FileMap<&'a str>>),
+    Context(Context, Diagnostics<'a>),
 }
 
 #[rustfmt::skip]

--- a/src/generator/code_gen_units.rs
+++ b/src/generator/code_gen_units.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::sync::Arc;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
@@ -39,7 +40,7 @@ pub enum StackElement<'a, D: Backend<'a>> {
     Graphviz(D::Graphviz),
 
     // resolve context
-    Context(Context, Diagnostics<'a>),
+    Context(Context, Arc<Diagnostics<'a>>),
 }
 
 use self::StackElement::*;

--- a/src/generator/code_gen_units.rs
+++ b/src/generator/code_gen_units.rs
@@ -1,4 +1,7 @@
 use std::io::{Result, Write};
+use std::sync::Arc;
+
+use codespan::FileMap;
 
 use crate::backend::{Backend, CodeGenUnit};
 use crate::config::Config;
@@ -36,7 +39,7 @@ pub enum StackElement<'a, D: Backend<'a>> {
     Graphviz(D::Graphviz),
 
     // resolve context
-    Context(Context),
+    Context(Context, Arc<FileMap<&'a str>>),
 }
 
 #[rustfmt::skip]
@@ -101,7 +104,7 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
             StackElement::NumberedEquation(s) => s.output_redirect(),
             StackElement::Graphviz(s) => s.output_redirect(),
 
-            StackElement::Context(_) => None,
+            StackElement::Context(..) => None,
         }
     }
 
@@ -134,7 +137,7 @@ impl<'a, D: Backend<'a>> StackElement<'a, D> {
             StackElement::NumberedEquation(s) => s.intercept_event(stack, e),
             StackElement::Graphviz(s) => s.intercept_event(stack, e),
 
-            StackElement::Context(_) => Ok(Some(e)),
+            StackElement::Context(..) => Ok(Some(e)),
         }
     }
 

--- a/src/generator/event.rs
+++ b/src/generator/event.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::ops::Range;
 use std::path::PathBuf;
 
 pub use crate::frontend::{
@@ -20,6 +19,7 @@ pub use crate::frontend::{
 pub use pulldown_cmark::Alignment;
 
 use crate::frontend::{Event as FeEvent, Tag as FeTag};
+use crate::frontend::range::WithRange;
 use crate::generator::Events;
 use crate::resolve::Command;
 
@@ -92,15 +92,15 @@ pub enum Tag<'a> {
 /// Image to display as figure.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Image<'a> {
-    pub label: Option<(Cow<'a, str>, Range<usize>)>,
-    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
+    pub label: Option<WithRange<Cow<'a, str>>>,
+    pub caption: Option<WithRange<Cow<'a, str>>>,
     pub title: Option<Cow<'a, str>>,
     pub alt_text: Option<String>,
     /// Path to read image from.
     pub path: PathBuf,
-    pub scale: Option<(Cow<'a, str>, Range<usize>)>,
-    pub width: Option<(Cow<'a, str>, Range<usize>)>,
-    pub height: Option<(Cow<'a, str>, Range<usize>)>,
+    pub scale: Option<WithRange<Cow<'a, str>>>,
+    pub width: Option<WithRange<Cow<'a, str>>>,
+    pub height: Option<WithRange<Cow<'a, str>>>,
 }
 
 /// Pdf to include at that point inline.

--- a/src/generator/event.rs
+++ b/src/generator/event.rs
@@ -18,15 +18,12 @@ pub use crate::frontend::{
 };
 pub use pulldown_cmark::Alignment;
 
-use enum_kinds::EnumKind;
-
 use crate::frontend::{Event as FeEvent, Tag as FeTag};
 use crate::resolve::Command;
 use crate::generator::Events;
 
 // transformation of frontend::Event
-#[derive(Debug, EnumKind)]
-#[enum_kind(EventKind)]
+#[derive(Debug)]
 pub enum Event<'a> {
     Start(Tag<'a>),
     End(Tag<'a>),
@@ -34,7 +31,7 @@ pub enum Event<'a> {
     Html(Cow<'a, str>),
     InlineHtml(Cow<'a, str>),
     Latex(Cow<'a, str>),
-    IncludeMarkdown(Events<'a>),
+    IncludeMarkdown(Box<Events<'a>>),
     FootnoteReference(FootnoteReference<'a>),
     BiberReferences(Vec<BiberReference<'a>>),
     /// Url without content

--- a/src/generator/event.rs
+++ b/src/generator/event.rs
@@ -22,6 +22,7 @@ use enum_kinds::EnumKind;
 
 use crate::frontend::{Event as FeEvent, Tag as FeTag};
 use crate::resolve::Command;
+use crate::generator::Events;
 
 // transformation of frontend::Event
 #[derive(Debug, EnumKind)]
@@ -33,6 +34,7 @@ pub enum Event<'a> {
     Html(Cow<'a, str>),
     InlineHtml(Cow<'a, str>),
     Latex(Cow<'a, str>),
+    IncludeMarkdown(Events<'a>),
     FootnoteReference(FootnoteReference<'a>),
     BiberReferences(Vec<BiberReference<'a>>),
     /// Url without content

--- a/src/generator/event.rs
+++ b/src/generator/event.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
-use std::path::PathBuf;
 use std::ops::Range;
+use std::path::PathBuf;
 
 pub use crate::frontend::{
     BiberReference,
@@ -20,8 +20,8 @@ pub use crate::frontend::{
 pub use pulldown_cmark::Alignment;
 
 use crate::frontend::{Event as FeEvent, Tag as FeTag};
-use crate::resolve::Command;
 use crate::generator::Events;
+use crate::resolve::Command;
 
 // transformation of frontend::Event
 #[derive(Debug)]

--- a/src/generator/event.rs
+++ b/src/generator/event.rs
@@ -18,11 +18,14 @@ pub use crate::frontend::{
 };
 pub use pulldown_cmark::Alignment;
 
+use enum_kinds::EnumKind;
+
 use crate::frontend::{Event as FeEvent, Tag as FeTag};
 use crate::resolve::Command;
 
 // transformation of frontend::Event
-#[derive(Debug)]
+#[derive(Debug, EnumKind)]
+#[enum_kind(EventKind)]
 pub enum Event<'a> {
     Start(Tag<'a>),
     End(Tag<'a>),

--- a/src/generator/event.rs
+++ b/src/generator/event.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
+use std::ops::Range;
 
 pub use crate::frontend::{
     BiberReference,
@@ -91,15 +92,15 @@ pub enum Tag<'a> {
 /// Image to display as figure.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Image<'a> {
-    pub label: Option<Cow<'a, str>>,
-    pub caption: Option<Cow<'a, str>>,
+    pub label: Option<(Cow<'a, str>, Range<usize>)>,
+    pub caption: Option<(Cow<'a, str>, Range<usize>)>,
     pub title: Option<Cow<'a, str>>,
     pub alt_text: Option<String>,
     /// Path to read image from.
     pub path: PathBuf,
-    pub scale: Option<Cow<'a, str>>,
-    pub width: Option<Cow<'a, str>>,
-    pub height: Option<Cow<'a, str>>,
+    pub scale: Option<(Cow<'a, str>, Range<usize>)>,
+    pub width: Option<(Cow<'a, str>, Range<usize>)>,
+    pub height: Option<(Cow<'a, str>, Range<usize>)>,
 }
 
 /// Pdf to include at that point inline.

--- a/src/generator/iter.rs
+++ b/src/generator/iter.rs
@@ -133,7 +133,7 @@ impl<'a> Iter<'a> {
                     .map_err(|err| {
                         gen.diagnostics()
                             .error("error reading markdown include file")
-                            .with_section(&range, "in this include")
+                            .with_error_section(&range, "in this include")
                             .error(format!("cause: {}", err))
                             .emit();
                         Error::Diagnostic

--- a/src/generator/iter.rs
+++ b/src/generator/iter.rs
@@ -1,0 +1,175 @@
+use std::ops::Range;
+use std::io::Write;
+use std::fs;
+use std::iter::Fuse;
+
+use crate::error::{FatalResult, Error, Result};
+use crate::frontend::{Frontend, Event as FeEvent, EventKind as FeEventKind, Include as FeInclude};
+use crate::generator::Generator;
+use crate::generator::event::{Event, Image, Pdf};
+use crate::backend::Backend;
+use crate::resolve::{Include, Context};
+use crate::diagnostics::Input;
+
+pub struct Iter<'a> {
+    frontend: Fuse<Frontend<'a>>,
+    peek: Option<(Event<'a>, Range<usize>)>,
+    last_kind: FeEventKind,
+}
+
+impl<'a> Iter<'a> {
+    pub fn new(frontend: Frontend<'a>) -> Self {
+        Iter {
+            frontend: frontend.fuse(),
+            peek: None,
+            last_kind: FeEventKind::Start,
+        }
+    }
+
+    /// Retrieves and converts the next event that needs to be handled.
+    ///
+    /// If it's an include which is handled, it'll be handled internally and the next event will
+    /// be returned. If there is some diagnostic error, it'll skip over that event and return
+    /// the next one which should be handled.
+    pub fn next(&mut self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>) -> FatalResult<Option<(Event<'a>, Range<usize>)>> {
+        if let Some(peek) = self.peek.take() {
+            self.last_kind = FeEventKind::from(&peek.0);
+            return Ok(Some(peek));
+        }
+        loop {
+            match self.frontend.next() {
+                None => return Ok(None),
+                Some((event, range)) => {
+                    self.last_kind = FeEventKind::from(&event);
+                    match self.convert_event(event, range.clone(), gen) {
+                        Ok(None) => continue,
+                        Ok(Some(event)) => return Ok(Some((event, range))),
+                        Err(Error::Diagnostic) => self.skip(gen)?,
+                        Err(Error::Fatal(fatal)) => return Err(fatal),
+                    }
+                },
+            }
+        }
+    }
+
+    pub fn peek(&mut self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>) -> FatalResult<Option<(&Event<'a>, Range<usize>)>> {
+        if let Some((peek, peek_range)) = &self.peek {
+            return Ok(Some((peek, peek_range.clone())));
+        }
+        self.peek = self.next(gen)?;
+        Ok(self.peek.as_ref().map(|(peek, range)| (peek, range.clone())))
+    }
+
+    /// Skips events until the next one that can be handled again.
+    pub fn skip(&mut self, gen: &mut Generator<'a, impl Backend<'a>, impl Write>) -> FatalResult<()> {
+        match self.last_kind {
+            // continue consuming until end
+            FeEventKind::Start => (),
+            // TODO: unsure if `End` might just be unrecoverable
+            FeEventKind::End
+            | FeEventKind::Text
+            | FeEventKind::Html
+            | FeEventKind::InlineHtml
+            | FeEventKind::Latex
+            | FeEventKind::FootnoteReference
+            | FeEventKind::BiberReferences
+            | FeEventKind::Url
+            | FeEventKind::InterLink
+            | FeEventKind::Include
+            | FeEventKind::Label
+            | FeEventKind::SoftBreak
+            | FeEventKind::HardBreak
+            | FeEventKind::TaskListMarker
+            | FeEventKind::Command
+            | FeEventKind::ResolveInclude => return Ok(()),
+        }
+        let mut depth = 0;
+        loop {
+            let evt = if let Some((peek, _)) = self.peek.take() {
+                peek
+            } else {
+                self.next(gen)?.0
+            };
+            match evt {
+                FeEvent::Start(_) => depth += 1,
+                FeEvent::End(_) if depth > 0 => depth -= 1,
+                FeEvent::End(_) => return Ok(()),
+                _ => {},
+            }
+        }
+    }
+
+    /// Converts an event, resolving any includes. If the include is handled, returns Ok(None).
+    /// If it fails, returns the original event.
+    fn convert_event(
+        &mut self, event: FeEvent<'a>, range: Range<usize>,
+        gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
+    ) -> Result<Event<'a>> {
+        match event {
+            FeEvent::Include(image) => {
+                let include = gen.resolve(&image.dst, range.clone())?;
+                self.convert_include(include, Some(image), range)
+            },
+            FeEvent::ResolveInclude(include) => {
+                let include = gen.resolve(&include, range.clone())?;
+                self.convert_include(include, None, range)
+            },
+            e => Ok(Some(e.into())),
+        }
+    }
+
+    fn convert_include(
+        &mut self, include: Include, image: Option<FeInclude<'a>>, range: Range<usize>,
+    ) -> Result<Event<'a>> {
+        match include {
+            Include::Command(command) => Ok(command.into()),
+            Include::Markdown(path, context) => {
+                let markdown = fs::read_to_string(&path)
+                    .map_err(|err| {
+                        self.diagnostics()
+                            .error("error reading markdown include file")
+                            .with_section(&range, "in this include")
+                            .error(format!("cause: {}", err))
+                            .emit();
+                        Error::Diagnostic
+                    })?;
+                let input = match &context {
+                    Context::Remote(url) => Input::Url(url.clone()),
+                    Context::LocalRelative(_)
+                    | Context::LocalAbsolute(_) => Input::File(path.clone()),
+                };
+                let events = self.get_events(markdown, context, input);
+                Ok(Event::IncludeMarkdown(events))
+            },
+            Include::Image(path) => {
+                let (label, caption, title, alt_text, scale, width, height) =
+                    if let Some(FeInclude {
+                                    label,
+                                    caption,
+                                    title,
+                                    alt_text,
+                                    dst: _dst,
+                                    scale,
+                                    width,
+                                    height,
+                                }) = image
+                    {
+                        (label, caption, title, alt_text, scale, width, height)
+                    } else {
+                        Default::default()
+                    };
+                Ok(Event::Image(Image {
+                    label,
+                    caption,
+                    title,
+                    alt_text,
+                    path,
+                    scale,
+                    width,
+                    height,
+                }))
+            },
+            Include::Pdf(path) => Ok(Event::Pdf(Pdf { path })),
+        }
+    }
+}

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -202,6 +202,14 @@ impl<'a, B: Backend<'a>, W: Write> Generator<'a, B, W> {
             .unwrap_or(&mut self.default_out)
     }
 
+    pub fn diagnostics(&self) -> &Diagnostics<'a> {
+        self.iter_stack()
+            .filter_map(|state| match state {
+                StackElement::Context(_, diagnostics) => Some(diagnostics),
+                _ => None,
+            }).next().unwrap()
+    }
+
     fn resolve(&mut self, url: &str) -> Result<Include> {
         let context = self
             .iter_stack()

--- a/src/generator/stack.rs
+++ b/src/generator/stack.rs
@@ -27,6 +27,7 @@ impl<'a: 'b, 'b, D: Backend<'a> + 'b, W: Write> Stack<'a, 'b, D, W> {
             .unwrap_or(self.default_out)
     }
 
+    #[allow(dead_code)]
     pub fn diagnostics(&mut self) -> &mut Diagnostics<'a> {
         self.stack
             .iter_mut()

--- a/src/generator/stack.rs
+++ b/src/generator/stack.rs
@@ -28,7 +28,7 @@ impl<'a: 'b, 'b, D: Backend<'a> + 'b, W: Write> Stack<'a, 'b, D, W> {
     }
 
     #[allow(dead_code)]
-    pub fn diagnostics(&mut self) -> &mut Diagnostics<'a> {
+    pub fn diagnostics(&mut self) -> &Diagnostics<'a> {
         self.stack
             .iter_mut()
             .rev()

--- a/src/generator/stack.rs
+++ b/src/generator/stack.rs
@@ -28,10 +28,14 @@ impl<'a: 'b, 'b, D: Backend<'a> + 'b, W: Write> Stack<'a, 'b, D, W> {
     }
 
     pub fn diagnostics(&mut self) -> &mut Diagnostics<'a> {
-        self.stack.iter_mut().rev()
+        self.stack
+            .iter_mut()
+            .rev()
             .filter_map(|state| match state {
                 StackElement::Context(_, diagnostics) => Some(diagnostics),
                 _ => None,
-            }).next().unwrap()
+            })
+            .next()
+            .unwrap()
     }
 }

--- a/src/generator/stack.rs
+++ b/src/generator/stack.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 
 use super::StackElement;
 use crate::backend::Backend;
+use crate::diagnostics::Diagnostics;
 
 pub struct Stack<'a: 'b, 'b, D: Backend<'a>, W: Write> {
     default_out: &'b mut W,
@@ -14,7 +15,7 @@ impl<'a: 'b, 'b, D: Backend<'a> + 'b, W: Write> Stack<'a, 'b, D, W> {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &StackElement<'a, D>> {
-        self.stack.iter()
+        self.stack.iter().rev()
     }
 
     pub fn get_out(&mut self) -> &mut dyn Write {
@@ -24,5 +25,13 @@ impl<'a: 'b, 'b, D: Backend<'a> + 'b, W: Write> Stack<'a, 'b, D, W> {
             .filter_map(|state| state.output_redirect())
             .next()
             .unwrap_or(self.default_out)
+    }
+
+    pub fn diagnostics(&self) -> &Diagnostics<'a> {
+        self.iter()
+            .filter_map(|state| match state {
+                StackElement::Context(_, diagnostics) => Some(diagnostics),
+                _ => None,
+            }).next().unwrap()
     }
 }

--- a/src/generator/stack.rs
+++ b/src/generator/stack.rs
@@ -27,8 +27,8 @@ impl<'a: 'b, 'b, D: Backend<'a> + 'b, W: Write> Stack<'a, 'b, D, W> {
             .unwrap_or(self.default_out)
     }
 
-    pub fn diagnostics(&self) -> &Diagnostics<'a> {
-        self.iter()
+    pub fn diagnostics(&mut self) -> &mut Diagnostics<'a> {
+        self.stack.iter_mut().rev()
             .filter_map(|state| match state {
                 StackElement::Context(_, diagnostics) => Some(diagnostics),
                 _ => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ mod resolve;
 
 use crate::backend::latex::{Article, Report, Thesis};
 use crate::config::{CliArgs, Config, DocumentType, FileConfig, OutType};
+use crate::error::Fatal;
 
 fn main() {
     let args = CliArgs::from_args();
@@ -109,16 +110,20 @@ fn main() {
 }
 
 fn gen(cfg: &Config, markdown: String, out: impl Write) {
-    match cfg.document_type {
+    let res = match cfg.document_type {
         DocumentType::Article => {
-            backend::generate(cfg, Article, &Arena::new(), markdown, out).unwrap()
+            backend::generate(cfg, Article, &Arena::new(), markdown, out)
         },
         DocumentType::Report => {
-            backend::generate(cfg, Report, &Arena::new(), markdown, out).unwrap()
+            backend::generate(cfg, Report, &Arena::new(), markdown, out)
         },
         DocumentType::Thesis => {
-            backend::generate(cfg, Thesis, &Arena::new(), markdown, out).unwrap()
+            backend::generate(cfg, Thesis, &Arena::new(), markdown, out)
         },
+    };
+    match res {
+        Ok(()) => (),
+        Err(Fatal::Output(io)) => eprintln!("\n\nerror writing to output: {}", io),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ fn gen(cfg: &Config, markdown: String, out: impl Write) {
     match res {
         Ok(()) => (),
         Err(Fatal::Output(io)) => eprintln!("\n\nerror writing to output: {}", io),
-        Err(Fatal::InternalError) => eprintln!("\n\nCan not continue due to internal error"),
+        Err(Fatal::InteralCompilerError) => eprintln!("\n\nCan not continue due to internal error"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,10 +33,12 @@ use std::fs::{self, File};
 use std::io::{self, Result, Write};
 use std::path::Path;
 use std::process::Command;
+use std::sync::{Arc, Mutex};
 
 use structopt::StructOpt;
 use tempdir::TempDir;
 use typed_arena::Arena;
+use codespan_reporting::termcolor::{ColorChoice, StandardStream};
 
 mod backend;
 mod config;
@@ -110,10 +112,12 @@ fn main() {
 }
 
 fn gen(cfg: &Config, markdown: String, out: impl Write) {
+    // TODO: make this configurable
+    let stderr = Arc::new(Mutex::new(StandardStream::stderr(ColorChoice::Auto)));
     let res = match cfg.document_type {
-        DocumentType::Article => backend::generate(cfg, Article, &Arena::new(), markdown, out),
-        DocumentType::Report => backend::generate(cfg, Report, &Arena::new(), markdown, out),
-        DocumentType::Thesis => backend::generate(cfg, Thesis, &Arena::new(), markdown, out),
+        DocumentType::Article => backend::generate(cfg, Article, &Arena::new(), markdown, out, stderr),
+        DocumentType::Report => backend::generate(cfg, Report, &Arena::new(), markdown, out, stderr),
+        DocumentType::Thesis => backend::generate(cfg, Thesis, &Arena::new(), markdown, out, stderr),
     };
     match res {
         Ok(()) => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ use typed_arena::Arena;
 mod backend;
 mod config;
 mod cskvp;
+mod diagnostics;
 mod ext;
 mod frontend;
 mod generator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,7 @@ fn gen(cfg: &Config, markdown: String, out: impl Write) {
     match res {
         Ok(()) => (),
         Err(Fatal::Output(io)) => eprintln!("\n\nerror writing to output: {}", io),
+        Err(Fatal::InternalError) => eprintln!("\n\nCan not continue due to internal error"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@
 #![warn(trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 #![warn(unused_qualifications)]
-#![warn(variant_size_differences)]
 // for now
+#![allow(variant_size_differences)]
 #![allow(missing_docs)]
 // seems to have quite some unchangeable false positives
 // might need further inspection

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ mod backend;
 mod config;
 mod cskvp;
 mod diagnostics;
+mod error;
 mod ext;
 mod frontend;
 mod generator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,15 +111,9 @@ fn main() {
 
 fn gen(cfg: &Config, markdown: String, out: impl Write) {
     let res = match cfg.document_type {
-        DocumentType::Article => {
-            backend::generate(cfg, Article, &Arena::new(), markdown, out)
-        },
-        DocumentType::Report => {
-            backend::generate(cfg, Report, &Arena::new(), markdown, out)
-        },
-        DocumentType::Thesis => {
-            backend::generate(cfg, Thesis, &Arena::new(), markdown, out)
-        },
+        DocumentType::Article => backend::generate(cfg, Article, &Arena::new(), markdown, out),
+        DocumentType::Report => backend::generate(cfg, Report, &Arena::new(), markdown, out),
+        DocumentType::Thesis => backend::generate(cfg, Thesis, &Arena::new(), markdown, out),
     };
     match res {
         Ok(()) => (),

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -189,7 +189,6 @@ mod tests {
 
         assert_match!(main, Include::Markdown(path, _) if path == &dir.path().join("main.md"));
         assert_match!(sibling, Include::Image(path) if path == &dir.path().join("image.png"));
-        drop(dir);
     }
 
     #[test]
@@ -203,7 +202,6 @@ mod tests {
             .expect("Failed to resolve path in different domain");
 
         assert_eq!(toc, Include::Command(Command::Toc));
-        drop(dir);
     }
 
     #[test]
@@ -222,7 +220,6 @@ mod tests {
             .expect("Failed to download external document");
 
         assert_match!(external, Include::Markdown(_, Context::Remote(_)));
-        drop(dir);
     }
 
     #[test]
@@ -233,10 +230,9 @@ mod tests {
 
         let error = resolver
             .resolve(&top, "this_file_does_not_exist.md", range, &mut diagnostics)
-            .expect_err("Can not resolve source for files that do not exist on disk");
+            .expect_err("Only files that exist on disk can be resolved");
 
         assert_match!(error, Error::Diagnostic);
-        drop(dir);
     }
 
     #[test]

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -224,4 +224,18 @@ mod tests {
         assert_match!(external, Include::Markdown(_, Context::Remote(_)));
         drop(dir);
     }
+
+    #[test]
+    fn local_resolves_not_exist_not_internal_bug() {
+        let (dir, range, mut diagnostics) = prepare();
+        let resolver = Resolver::new(PathBuf::from("."), dir.path().join("download"));
+        let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
+
+        let error = resolver
+            .resolve(&top, "this_file_does_not_exist.md", range, &mut diagnostics)
+            .expect_err("Can not resolve source for files that do not exist on disk");
+
+        assert_match!(error, Error::Diagnostic);
+        drop(dir);
+    }
 }

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -51,7 +51,7 @@ impl Resolver {
             Ok(url) => url,
             Err(err) => {
                 diagnostics.error("couldn't resolve file")
-                    .with_section(&range, "defined here")
+                    .with_error_section(&range, "defined here")
                     .note(format!("tried to resolve {}", url))
                     .note(format!("malformed reference: {}", err))
                     .emit();
@@ -85,7 +85,7 @@ impl Resolver {
             | (Context::LocalAbsolute(_), SourceGroup::Remote) => {
                 diagnostics
                     .error("permission denied")
-                    .with_section(&range, "trying to include this")
+                    .with_error_section(&range, "trying to include this")
                     .note("local absolute path not allowed to access remote or local relative files")
                     .emit();
                 Err(Error::Diagnostic)
@@ -97,7 +97,7 @@ impl Resolver {
                 } else {
                     diagnostics
                         .error("permission denied")
-                        .with_section(&range, "trying to include this")
+                        .with_error_section(&range, "trying to include this")
                         .note(format!("not allowed to access absolute path {:?}", path))
                         .emit();
                     Err(Error::Diagnostic)
@@ -109,7 +109,7 @@ impl Resolver {
             (Context::Remote(_), _) => {
                 diagnostics
                     .error("permission denied")
-                    .with_section(&range, "trying to include this")
+                    .with_error_section(&range, "trying to include this")
                     .note("remote file can only include other remote content")
                     .emit();
                 Err(Error::Diagnostic)

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -161,14 +161,14 @@ mod tests {
     });
 }
 
-    fn prepare() -> (TempDir, SourceRange, Diagnostics<'_>) {
+    fn prepare() -> (TempDir, SourceRange, Diagnostics<'static>) {
         let dir = TempDir::new("heradoc-test").expect("Can't create tempdir");
         let _ = File::create(dir.path().join("main.md")).expect("Can't create main.md");
         let _ = File::create(dir.path().join("test.md")).expect("Can't create main.md");
         let _ = File::create(dir.path().join("image.png")).expect("Can't create image.png");
         let _ = File::create(dir.path().join("pdf.pdf")).expect("Can't create pdf.pdf");
-        let mut range = SourceRange { start: 0, end: 0 };
-        let mut diagnostics = Diagnostics::new("", Input::Stdin);
+        let range = SourceRange { start: 0, end: 0 };
+        let diagnostics = Diagnostics::new("", Input::Stdin);
         (dir, range, diagnostics)
     }
 

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -238,4 +238,32 @@ mod tests {
         assert_match!(error, Error::Diagnostic);
         drop(dir);
     }
+
+    #[test]
+    fn local_absolute_url_to_relative() {
+        let (dir, range, mut diagnostics) = prepare();
+        let resolver = Resolver::new(PathBuf::from("."), dir.path().join("download"));
+        let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
+
+        let url = Url::from_file_path(dir.path().join("main.md")).unwrap();
+        let main = resolver
+            .resolve(&top, url.as_str(), range, &mut diagnostics)
+            .expect("Failed to resolve absolute file url");
+
+        assert_match!(main, Include::Markdown(_, Context::LocalRelative(_)));
+    }
+
+    #[test]
+    fn local_url_does_not_exist() {
+        let (dir, range, mut diagnostics) = prepare();
+        let resolver = Resolver::new(PathBuf::from("."), dir.path().join("download"));
+        let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
+
+        let url = Url::from_file_path(dir.path().join("this_file_does_not_exist.md")).unwrap();
+        let error = resolver
+            .resolve(&top, url.as_str(), range, &mut diagnostics)
+            .expect_err("Failed to resolve absolute file url");
+
+        assert_match!(error, Error::Diagnostic);
+    }
 }

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -87,8 +87,8 @@ impl Resolver {
             },
 
             // TODO: think about proper remote rules
-            (Context::Remote, SourceGroup::Remote) => Ok(()),
-            (Context::Remote, _) => Err(io::Error::new(
+            (Context::Remote(_), SourceGroup::Remote) => Ok(()),
+            (Context::Remote(_), _) => Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 "Remote can only access remote",
             )),
@@ -100,14 +100,14 @@ impl Resolver {
 pub enum Context {
     LocalRelative(PathBuf),
     LocalAbsolute(PathBuf),
-    Remote,
+    Remote(Url),
 }
 
 impl Context {
     fn path(&self) -> Option<&Path> {
         match self {
             Context::LocalRelative(path) | Context::LocalAbsolute(path) => Some(path),
-            Context::Remote => None,
+            Context::Remote(_) => None,
         }
     }
 }
@@ -181,7 +181,7 @@ mod tests {
             .resolve(&top, "https://raw.githubusercontent.com/oberien/heradoc/master/README.md")
             .expect("Failed to download external document");
 
-        assert_match!(external, Include::Markdown(_, Context::Remote));
+        assert_match!(external, Include::Markdown(_, Context::Remote(_)));
         drop(dir);
     }
 }

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -9,7 +9,9 @@
 //! an open read stream or to an auxiliary file. Secondly, this resolution will automatically apply
 //! a restrictive-by-default filter and error when violating security boundaries.
 use std::io;
+use std::result::Result;
 use std::path::{Path, PathBuf};
+use std::ops::Range;
 
 use url::Url;
 
@@ -20,6 +22,7 @@ mod source;
 pub use self::include::*;
 use self::remote::Remote;
 use self::source::{Source, SourceGroup};
+use crate::diagnostics::Diagnostics;
 
 pub struct Resolver {
     base: Url,
@@ -42,19 +45,26 @@ impl Resolver {
     }
 
     /// Make a request to an uri in the context of a document with the specified source.
-    pub fn resolve(&self, context: &Context, url: &str) -> io::Result<Include> {
-        let url = self.base.join(url).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::AddrNotAvailable,
-                format!("Malformed reference: {:?}", err),
-            )
-        })?;
+    pub fn resolve(
+        &self, context: &Context, url: &str, range: Range<usize>, diagnostics: &mut Diagnostics<'_>
+    ) -> Result<Include, ()> {
+        let url = match self.base.join(url) {
+            Ok(url) => url,
+            Err(err) => {
+                diagnostics.error("couldn't resolve file")
+                    .with_section(&range, "defined here")
+                    .note(format!("tried to resolve {}", url))
+                    .note(format!("malformed reference: {}", err))
+                    .emit();
+                return Err(());
+            }
+        };
 
-        let target = Source::new(url, context)?;
+        let target = Source::new(url, context, range, diagnostics)?;
         // check if context is allowed to access target
-        self.check_access(context, &target)?;
+        self.check_access(context, &target, range, diagnostics)?;
 
-        target.into_include(&self.remote)
+        target.into_include(&self.remote, range, diagnostics)
     }
 
     /// Test if the source is allowed to request the target document.
@@ -62,7 +72,10 @@ impl Resolver {
     /// Some origins are not allowed to read all documents or only after explicit clearance by the
     /// invoking user.  Even more restrictive, the target handler could terminate the request at a
     /// later time. For example when requesting a remote document make a CORS check.
-    fn check_access(&self, context: &Context, target: &Source) -> io::Result<()> {
+    fn check_access(
+        &self, context: &Context, target: &Source, range: Range<usize>,
+        diagnostics: &mut Diagnostics<'_>
+    ) -> Result<(), ()> {
         match (context, &target.group) {
             (Context::LocalRelative(_), SourceGroup::Implementation)
             | (Context::LocalRelative(_), SourceGroup::LocalRelative(_))
@@ -70,28 +83,38 @@ impl Resolver {
 
             (Context::LocalAbsolute(_), SourceGroup::Implementation) => Ok(()),
             (Context::LocalAbsolute(_), SourceGroup::LocalRelative(_))
-            | (Context::LocalAbsolute(_), SourceGroup::Remote) => Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "Local absolute path not allowed to access remote file",
-            )),
+            | (Context::LocalAbsolute(_), SourceGroup::Remote) => {
+                diagnostics
+                    .error("permission denied")
+                    .with_section(&range, "trying to include this")
+                    .note("local absolute path not allowed to access remote or local relative files")
+                    .emit();
+                Err(())
+            },
 
             (_, SourceGroup::LocalAbsolute(path)) => {
                 if self.permissions.allowed_absolute_folders.contains(path) {
                     Ok(())
                 } else {
-                    Err(io::Error::new(
-                        io::ErrorKind::PermissionDenied,
-                        format!("Not allowed to access absolute path {:?}", path),
-                    ))
+                    diagnostics
+                        .error("permission denied")
+                        .with_section(&range, "trying to include this")
+                        .note(format!("not allowed to access absolute path {:?}", path))
+                        .emit();
+                    Err(())
                 }
             },
 
             // TODO: think about proper remote rules
             (Context::Remote(_), SourceGroup::Remote) => Ok(()),
-            (Context::Remote(_), _) => Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "Remote can only access remote",
-            )),
+            (Context::Remote(_), _) => {
+                diagnostics
+                    .error("permission denied")
+                    .with_section(&range, "trying to include this")
+                    .note("remote file can only include other remote content")
+                    .emit();
+                Err(())
+            },
         }
     }
 }
@@ -117,6 +140,7 @@ mod tests {
     use super::*;
     use std::fs::File;
     use tempdir::TempDir;
+    use crate::diagnostics::Input;
 
     macro_rules! assert_match {
     ($left:expr, $right:pat if $cond:expr) => ({
@@ -135,23 +159,25 @@ mod tests {
     });
 }
 
-    fn prepare() -> TempDir {
+    fn prepare() -> (TempDir, Range<usize>, Diagnostics<'_>) {
         let dir = TempDir::new("heradoc-test").expect("Can't create tempdir");
         let _ = File::create(dir.path().join("main.md")).expect("Can't create main.md");
         let _ = File::create(dir.path().join("test.md")).expect("Can't create main.md");
         let _ = File::create(dir.path().join("image.png")).expect("Can't create image.png");
         let _ = File::create(dir.path().join("pdf.pdf")).expect("Can't create pdf.pdf");
-        dir
+        let mut range = Range { start: 0, end: 0 };
+        let mut diagnostics = Diagnostics::new("", Input::Stdin);
+        (dir, range, diagnostics)
     }
 
     #[test]
     fn standard_resolves() {
-        let dir = prepare();
+        let (dir, range, mut diagnostics) = prepare();
         let resolver = Resolver::new(PathBuf::from("."), dir.path().join("download"));
         let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
 
-        let main = resolver.resolve(&top, "main.md").expect("Failed to resolve direct path");
-        let sibling = resolver.resolve(&top, "image.png").expect("Failed to resolve sibling file");
+        let main = resolver.resolve(&top, "main.md", range.clone(), &mut diagnostics).expect("Failed to resolve direct path");
+        let sibling = resolver.resolve(&top, "image.png", range, &mut diagnostics).expect("Failed to resolve sibling file");
 
         assert_match!(main, Include::Markdown(path, _) if path == &dir.path().join("main.md"));
         assert_match!(sibling, Include::Image(path) if path == &dir.path().join("image.png"));
@@ -160,12 +186,12 @@ mod tests {
 
     #[test]
     fn domain_resolves() {
-        let dir = prepare();
+        let (dir, range, mut diagnostics) = prepare();
         let resolver = Resolver::new(PathBuf::from("."), dir.path().join("download"));
         let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
 
         let toc =
-            resolver.resolve(&top, "//toc").expect("Failed to resolve path in different domain");
+            resolver.resolve(&top, "//toc", range, &mut diagnostics).expect("Failed to resolve path in different domain");
 
         assert_eq!(toc, Include::Command(Command::Toc));
         drop(dir);
@@ -173,13 +199,15 @@ mod tests {
 
     #[test]
     fn http_resolves_needs_internet() {
-        let dir = prepare();
+        let (dir, range, mut diagnostics) = prepare();
         let resolver = Resolver::new(PathBuf::from("."), dir.path().join("download"));
         let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
 
         let external = resolver
-            .resolve(&top, "https://raw.githubusercontent.com/oberien/heradoc/master/README.md")
-            .expect("Failed to download external document");
+            .resolve(
+                &top, "https://raw.githubusercontent.com/oberien/heradoc/master/README.md",
+                range, &mut diagnostics,
+            ).expect("Failed to download external document");
 
         assert_match!(external, Include::Markdown(_, Context::Remote(_)));
         drop(dir);

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -60,9 +60,9 @@ impl Resolver {
             },
         };
 
-        let target = Source::new(url, context, range.clone(), diagnostics)?;
+        let target = Source::new(url, context, range, diagnostics)?;
         // check if context is allowed to access target
-        self.check_access(context, &target, range.clone(), diagnostics)?;
+        self.check_access(context, &target, range, diagnostics)?;
 
         target.into_include(&self.remote, range, diagnostics)
     }
@@ -179,7 +179,7 @@ mod tests {
         let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
 
         let main = resolver
-            .resolve(&top, "main.md", range.clone(), &mut diagnostics)
+            .resolve(&top, "main.md", range, &mut diagnostics)
             .expect("Failed to resolve direct path");
         let sibling = resolver
             .resolve(&top, "image.png", range, &mut diagnostics)

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -8,7 +8,6 @@
 //! This module provides an interface for both problems. First, it allows resolution of an url to
 //! an open read stream or to an auxiliary file. Secondly, this resolution will automatically apply
 //! a restrictive-by-default filter and error when violating security boundaries.
-use std::io;
 use std::path::{Path, PathBuf};
 use std::ops::Range;
 

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -59,9 +59,9 @@ impl Resolver {
             }
         };
 
-        let target = Source::new(url, context, range, diagnostics)?;
+        let target = Source::new(url, context, range.clone(), diagnostics)?;
         // check if context is allowed to access target
-        self.check_access(context, &target, range, diagnostics)?;
+        self.check_access(context, &target, range.clone(), diagnostics)?;
 
         target.into_include(&self.remote, range, diagnostics)
     }

--- a/src/resolve/source.rs
+++ b/src/resolve/source.rs
@@ -42,7 +42,7 @@ pub enum SourceGroup {
 fn error_include_local_from_remote(diagnostics: &mut Diagnostics<'_>, range: &Range<usize>) -> Error {
     diagnostics
         .error("tried to include local file from remote origin")
-        .with_section(range, "specified here")
+        .with_error_section(range, "specified here")
         .note("local files can only be included from within local files")
         .emit();
     Error::Diagnostic
@@ -51,7 +51,7 @@ fn error_include_local_from_remote(diagnostics: &mut Diagnostics<'_>, range: &Ra
 fn error_to_path(diagnostics: &mut Diagnostics<'_>, range: &Range<usize>, err: io::Error) -> Error {
     diagnostics
         .bug("error converting url to path")
-        .with_section(&range, "defined here")
+        .with_info_section(&range, "defined here")
         .error(format!("cause: {}", err))
         .emit();
     Error::Diagnostic
@@ -101,14 +101,14 @@ impl Source {
                     } else {
                         diagnostics
                             .error(format!("no heradoc implementation found for domain {:?}", domain))
-                            .with_section(&range, "defined here")
+                            .with_error_section(&range, "defined here")
                             .emit();
                         Err(Error::Diagnostic)
                     }
                 } else {
                     diagnostics
                         .error("no heradoc implementation domain found")
-                        .with_section(&range, "defined here")
+                        .with_error_section(&range, "defined here")
                         .emit();
                     Err(Error::Diagnostic)
                 }
@@ -127,7 +127,7 @@ impl Source {
                     Err(RemoteError::Io(err)) => {
                         diagnostics
                             .error("error writing downloaded content to cache")
-                            .with_section(&range, "trying to download this")
+                            .with_error_section(&range, "trying to download this")
                             .error(format!("cause: {}", err))
                             .emit();
                         return Err(Error::Diagnostic);
@@ -135,7 +135,7 @@ impl Source {
                     Err(RemoteError::Request(err)) => {
                         diagnostics
                             .error("error downloading content")
-                            .with_section(&range, "trying to download this")
+                            .with_error_section(&range, "trying to download this")
                             .error(format!("cause: {}", err))
                             .emit();
                         return Err(Error::Diagnostic);
@@ -172,14 +172,14 @@ fn to_include(
         Some(ext) => {
             diagnostics
                 .error(format!("unknown file format {:?}", ext))
-                .with_section(&range, "trying to include this")
+                .with_error_section(&range, "trying to include this")
                 .emit();
             Err(Error::Diagnostic)
         },
         None => {
             diagnostics
                 .error("no file extension")
-                .with_section(&range, "trying to include this")
+                .with_error_section(&range, "trying to include this")
                 .note("need file extension to differentiate file type")
                 .emit();
             Err(Error::Diagnostic)

--- a/src/resolve/source.rs
+++ b/src/resolve/source.rs
@@ -40,7 +40,7 @@ pub enum SourceGroup {
 }
 
 fn error_include_local_from_remote(
-    diagnostics: &mut Diagnostics<'_>, range: SourceRange,
+    diagnostics: &Diagnostics<'_>, range: SourceRange,
 ) -> Error {
     diagnostics
         .error("tried to include local file from remote origin")
@@ -50,7 +50,7 @@ fn error_include_local_from_remote(
     Error::Diagnostic
 }
 
-fn error_to_path(diagnostics: &mut Diagnostics<'_>, range: SourceRange, err: io::Error) -> Error {
+fn error_to_path(diagnostics: &Diagnostics<'_>, range: SourceRange, err: io::Error) -> Error {
     diagnostics
         .bug("error converting url to path")
         .with_info_section(range, "defined here")
@@ -61,7 +61,7 @@ fn error_to_path(diagnostics: &mut Diagnostics<'_>, range: SourceRange, err: io:
 
 impl Source {
     pub fn new(
-        url: Url, context: &Context, range: SourceRange, diagnostics: &mut Diagnostics<'_>,
+        url: Url, context: &Context, range: SourceRange, diagnostics: &Diagnostics<'_>,
     ) -> Result<Self> {
         let group = match url.scheme() {
             "heradoc" => match url.domain() {
@@ -98,7 +98,7 @@ impl Source {
     }
 
     pub fn into_include(
-        self, remote: &Remote, range: SourceRange, diagnostics: &mut Diagnostics<'_>,
+        self, remote: &Remote, range: SourceRange, diagnostics: &Diagnostics<'_>,
     ) -> Result<Include> {
         let Source { url, group } = self;
         match group {
@@ -174,7 +174,7 @@ impl Source {
 /// includes that did not receive repsonse with a media type header. Matching is performed purely
 /// based on the file extension.
 fn to_include(
-    path: PathBuf, context: Context, range: SourceRange, diagnostics: &mut Diagnostics<'_>,
+    path: PathBuf, context: Context, range: SourceRange, diagnostics: &Diagnostics<'_>,
 ) -> Result<Include> {
     // TODO: switch on file header type first
     match path.extension().map(|s| s.to_str().unwrap()) {

--- a/src/resolve/source.rs
+++ b/src/resolve/source.rs
@@ -135,11 +135,12 @@ impl Source {
             SourceGroup::Remote => {
                 let downloaded = match remote.http(&url) {
                     Ok(downloaded) => downloaded,
-                    Err(RemoteError::Io(err)) => {
+                    Err(RemoteError::Io(err, path)) => {
                         diagnostics
                             .error("error writing downloaded content to cache")
                             .with_error_section(&range, "trying to download this")
                             .error(format!("cause: {}", err))
+                            .note(format!("file: {}", path.display()))
                             .emit();
                         return Err(Error::Diagnostic);
                     },

--- a/src/resolve/source.rs
+++ b/src/resolve/source.rs
@@ -77,7 +77,7 @@ fn error_include_local_from_remote(
 fn error_to_path(diagnostics: &Diagnostics<'_>, range: SourceRange, err: PathError) -> Error {
     let (diagnostics, error) = match &err {
         PathError::NoPath | PathError::MissingComponent => {
-            (diagnostics.bug("internal error converting url to path"), Error::Fatal(Fatal::InternalError))
+            (diagnostics.bug("internal error converting url to path"), Error::Fatal(Fatal::InteralCompilerError))
         },
         PathError::InvalidBase | PathError::InvalidComponent | PathError::NoCanonical(..) => {
             (diagnostics.error("error converting url to path"), Error::Diagnostic)

--- a/src/resolve/source.rs
+++ b/src/resolve/source.rs
@@ -105,7 +105,7 @@ impl Source {
                 };
 
                 let path = downloaded.path().to_owned();
-                let context = Context::Remote;
+                let context = Context::Remote(url);
 
                 match downloaded.content_type() {
                     Some(ContentType::Image) => Ok(Include::Image(path)),


### PR DESCRIPTION
This got larger than expected. To make this easier I have refactored the Generator into an `Iter` module and to enforce the `StackElement::Context` (which previously needed to be put on the stack by the caller).

Even if we print diagnostics / errors, I try to recover from then by skipping over the events resulting in diagnostics and continuing with the next ones. No matter how many diagnostics got printed, I still try to produce a pdf.

There are three types of errors:
1. Internal logic errors: They just panic and unwind the program.
2. Non-recoverable expected errors (Fatal errors): Like when the latex output stream errors while writing to it. They are bubbled up to the `main` and printed there.
3. Diagnostics: We try to recover from them and continue generating.

For a testrun, execute `cargo run -- examples/errors.md`.

Fix #21 

Example of an ICE output (this particular one should probably be fixed :) ):

```rust
- bench.md:214208:1
       |
214208 | ![Representation example](img/representation-overview.png)
       | -- defined here
       |
error: cause: No such file or directory (os error 2)

error: internal compiler error: error converting url to path
note: please report this
note: in heradoc file None name Some(backtrace::backtrace::trace_unsynchronized::h4edc62c197f1da24) line None address Some(0x55682b1aca6d)
note: in heradoc file None name Some(heradoc::diagnostics::Diagnostics::bug::h93d19dd5adb6e56f) line None address Some(0x55682b1ea7e5)
note: in heradoc file None name Some(heradoc::resolve::Resolver::resolve::h9d40ca2a9539900f) line None address Some(0x55682b1b5718)
note: in heradoc file None name Some(heradoc::generator::iter::Iter::next::h7b763bfe69fe5de2) line None address Some(0x55682b24ff81)
note: in heradoc file None name Some(heradoc::generator::iter::Iter::peek::ha0e91824631af9c0) line None address Some(0x55682b25477a)
note: in heradoc file None name Some(heradoc::generator::Generator<B,W>::generate_body::ha9a7b0303c2dce06) line None address Some(0x55682b23c948)
note: in heradoc file None name Some(heradoc::generator::Generator<B,W>::generate::h6c7617fc6ab18829) line None address Some(0x55682b233be5)
note: in heradoc file None name Some(heradoc::backend::generate::ha0f89092eff9bc78) line None address Some(0x55682b1f41e4)
note: in heradoc file None name Some(heradoc::main::h5c534d9e94344157) line None address Some(0x55682b1b8140)
note: in heradoc file None name Some(std::rt::lang_start::{{closure}}::h95a941aaf9dbbd15) line None address Some(0x55682b1a4c02)
note: in heradoc file Some("src/libstd/rt.rs") name Some("{{closure}}") line Some(49) address Some(0x55682b54bd92)
note: in heradoc file Some("src/libstd/panicking.rs") name Some("do_call<closure,i32>") line Some(293) address Some(0x55682b54bd92)
note: in heradoc file Some("src/libpanic_unwind/lib.rs") name Some("__rust_maybe_catch_panic") line Some(87) address Some(0x55682b555be9)
note: in heradoc file Some("src/libstd/panicking.rs") name Some("try<i32,closure>") line Some(272) address Some(0x55682b54c95c)
note: in heradoc file Some("src/libstd/panic.rs") name Some("catch_unwind<closure,i32>") line Some(388) address Some(0x55682b54c95c)
note: in heradoc file Some("src/libstd/rt.rs") name Some("lang_start_internal") line Some(48) address Some(0x55682b54c95c)
note: in heradoc file None name Some("main") line None address Some(0x55682b1bc281)
note: in heradoc file None name Some("__libc_start_main") line None address Some(0x7f17ad25b222)
note: in heradoc file None name Some("_start") line None address Some(0x55682b18719d)
note: in heradoc file None name None line None address None
```