### PR TITLE
Expect failed canonicalization correctly

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,9 @@ pub type FatalResult<T> = result::Result<T, Fatal>;
 pub enum Fatal {
     /// Output file write error.
     Output(io::Error),
+
+    /// An unrecoverable internal error.
+    InternalError,
 }
 
 impl From<io::Error> for Fatal {
@@ -24,6 +27,7 @@ impl std::error::Error for Fatal {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Fatal::Output(io) => Some(io),
+            Fatal::InteralCompilerError => None,
         }
     }
 }
@@ -32,6 +36,7 @@ impl fmt::Display for Fatal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Fatal::Output(io) => write!(f, "output file write error: {}", io),
+            Fatal::InteralCompilerError => write!(f, "can not continue due to internal error"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,8 +13,15 @@ pub enum Fatal {
     /// Output file write error.
     Output(io::Error),
 
-    /// An unrecoverable internal error.
-    InternalError,
+    /// An unrecoverable internal error (ICE).
+    ///
+    /// Used for assertions that are made but not completely or badly proven. For cases where this
+    /// can be related directly to an particular structure in an input file this error also
+    /// provides opportunities to log the relevant context in diagnostics as opposed to `unwrap` or
+    /// `expect` panicking.  For example this may occur due to an interface of a dependency being
+    /// more general than its usage herein but we can not expect full control over its
+    /// implementation.
+    InteralCompilerError,
 }
 
 impl From<io::Error> for Fatal {

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ fn gen(cfg: &Config, markdown: String, out: impl Write) {
     match res {
         Ok(()) => (),
         Err(Fatal::Output(io)) => eprintln!("\n\nerror writing to output: {}", io),
-        Err(Fatal::InternalError) => eprintln!("\n\nCan not continue due to internal error"),
+        Err(Fatal::InteralCompilerError) => eprintln!("\n\nCan not continue due to internal error"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,7 @@ fn gen(cfg: &Config, markdown: String, out: impl Write) {
     match res {
         Ok(()) => (),
         Err(Fatal::Output(io)) => eprintln!("\n\nerror writing to output: {}", io),
+        Err(Fatal::InternalError) => eprintln!("\n\nCan not continue due to internal error"),
     }
 }
 

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -189,7 +189,6 @@ mod tests {
 
         assert_match!(main, Include::Markdown(path, _) if path == &dir.path().join("main.md"));
         assert_match!(sibling, Include::Image(path) if path == &dir.path().join("image.png"));
-        drop(dir);
     }
 
     #[test]
@@ -203,7 +202,6 @@ mod tests {
             .expect("Failed to resolve path in different domain");
 
         assert_eq!(toc, Include::Command(Command::Toc));
-        drop(dir);
     }
 
     #[test]
@@ -222,7 +220,6 @@ mod tests {
             .expect("Failed to download external document");
 
         assert_match!(external, Include::Markdown(_, Context::Remote(_)));
-        drop(dir);
     }
 
     #[test]
@@ -233,10 +230,9 @@ mod tests {
 
         let error = resolver
             .resolve(&top, "this_file_does_not_exist.md", range, &mut diagnostics)
-            .expect_err("Can not resolve source for files that do not exist on disk");
+            .expect_err("Only files that exist on disk can be resolved");
 
         assert_match!(error, Error::Diagnostic);
-        drop(dir);
     }
 
     #[test]

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -224,4 +224,18 @@ mod tests {
         assert_match!(external, Include::Markdown(_, Context::Remote(_)));
         drop(dir);
     }
+
+    #[test]
+    fn local_resolves_not_exist_not_internal_bug() {
+        let (dir, range, mut diagnostics) = prepare();
+        let resolver = Resolver::new(PathBuf::from("."), dir.path().join("download"));
+        let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
+
+        let error = resolver
+            .resolve(&top, "this_file_does_not_exist.md", range, &mut diagnostics)
+            .expect_err("Can not resolve source for files that do not exist on disk");
+
+        assert_match!(error, Error::Diagnostic);
+        drop(dir);
+    }
 }

--- a/src/resolve/mod.rs
+++ b/src/resolve/mod.rs
@@ -238,4 +238,32 @@ mod tests {
         assert_match!(error, Error::Diagnostic);
         drop(dir);
     }
+
+    #[test]
+    fn local_absolute_url_to_relative() {
+        let (dir, range, mut diagnostics) = prepare();
+        let resolver = Resolver::new(PathBuf::from("."), dir.path().join("download"));
+        let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
+
+        let url = Url::from_file_path(dir.path().join("main.md")).unwrap();
+        let main = resolver
+            .resolve(&top, url.as_str(), range, &mut diagnostics)
+            .expect("Failed to resolve absolute file url");
+
+        assert_match!(main, Include::Markdown(_, Context::LocalRelative(_)));
+    }
+
+    #[test]
+    fn local_url_does_not_exist() {
+        let (dir, range, mut diagnostics) = prepare();
+        let resolver = Resolver::new(PathBuf::from("."), dir.path().join("download"));
+        let top = Context::LocalRelative(Path::new(dir.path()).canonicalize().unwrap());
+
+        let url = Url::from_file_path(dir.path().join("this_file_does_not_exist.md")).unwrap();
+        let error = resolver
+            .resolve(&top, url.as_str(), range, &mut diagnostics)
+            .expect_err("Failed to resolve absolute file url");
+
+        assert_match!(error, Error::Diagnostic);
+    }
 }

--- a/src/resolve/source.rs
+++ b/src/resolve/source.rs
@@ -77,7 +77,7 @@ fn error_include_local_from_remote(
 fn error_to_path(diagnostics: &Diagnostics<'_>, range: SourceRange, err: PathError) -> Error {
     let (diagnostics, error) = match &err {
         PathError::NoPath | PathError::MissingComponent => {
-            (diagnostics.bug("internal error converting url to path"), Error::Fatal(Fatal::InternalError))
+            (diagnostics.bug("internal error converting url to path"), Error::Fatal(Fatal::InteralCompilerError))
         },
         PathError::InvalidBase | PathError::InvalidComponent | PathError::NoCanonical(..) => {
             (diagnostics.error("error converting url to path"), Error::Diagnostic)


### PR DESCRIPTION
Canonicalization is required to ensure proper access rights and failure
to do so (for example from a missing file) should not be treated as an
internal implementation failure. Rather, it is most likely the input
file's fault from a malformed path.

An intermediate error type diagnoses different problems with path
normalization when resolving a relative file.