### PR TITLE
Fix code block range

### DIFF
--- a/src/cskvp.rs
+++ b/src/cskvp.rs
@@ -233,18 +233,34 @@ impl<'a> Parser<'a> {
 
         let WithRange(key, key_range) = self.next_single(&['=', ','], diagnostics)?;
 
-        let delim = self.skip_delimiter();
+        let (delim, delim_range) = self.skip_delimiter();
 
         if let Some('=') = delim {
             let WithRange(val, val_range) = self.next_single(&[','], diagnostics)?;
             let range = SourceRange { start: key_range.start, end: val_range.end };
             let res = Some(WithRange(Value::Double(key, val), range));
 
-            let delim = self.skip_delimiter();
-            assert!(delim == Some(',') || delim == None, "invalid comma seperated key value pair");
+            let (delim, delim_range) = self.skip_delimiter();
+            if !(delim == None || delim == Some(',')) {
+                diagnostics.error("invalid comma seperated key-value-pair")
+                    .with_info_section(range, "in this key-value-pair")
+                    .with_error_section(delim_range, "incorrect delimiter after value")
+                    .help("use `,` to separate key-value-pairs")
+                    .emit();
+                self.rest = Cow::Borrowed("");
+                return Ok(None);
+            }
             Ok(res)
         } else {
-            assert!(delim == Some(',') || delim == None, "invalid comma seperated value");
+            if !(delim == None || delim == Some(',')) {
+                diagnostics.error("invalid comma seperated value")
+                    .with_info_section(key_range, "in this value")
+                    .with_error_section(delim_range, "incorrect delimiter after value")
+                    .help("use `,` to separate values")
+                    .emit();
+                self.rest = Cow::Borrowed("");
+                return Ok(None);
+            }
             Ok(Some(WithRange(Value::Single(key), key_range)))
         }
     }
@@ -329,16 +345,19 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn skip_delimiter(&mut self) -> Option<char> {
+    fn skip_delimiter(&mut self) -> (Option<char>, SourceRange) {
         let len = self.rest.len();
         self.rest.trim_start_inplace();
         self.range.start += len - self.rest.len();
         let delim = self.rest.chars().next();
+        let mut range = SourceRange { start: self.range.start, end: self.range.start };
         if delim.is_some() {
-            self.rest.truncate_start(1);
-            self.range.start += 1;
+            let delim_len = delim.unwrap().len_utf8();
+            self.rest.truncate_start(delim_len);
+            self.range.start += delim_len;
+            range.end += delim_len;
         }
-        delim
+        (delim, range)
     }
 }
 

--- a/src/frontend/convert_cow.rs
+++ b/src/frontend/convert_cow.rs
@@ -17,7 +17,7 @@ impl<'a> Iterator for ConvertCow<'a> {
     type Item = WithRange<Event<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        dbg!(self.0.next()).map(|(e, r)| WithRange(e.into(), r.into()))
+        self.0.next().map(|(e, r)| WithRange(e.into(), r.into()))
     }
 }
 

--- a/src/frontend/convert_cow.rs
+++ b/src/frontend/convert_cow.rs
@@ -17,7 +17,7 @@ impl<'a> Iterator for ConvertCow<'a> {
     type Item = WithRange<Event<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|(e, r)| WithRange(e.into(), r.into()))
+        dbg!(self.0.next()).map(|(e, r)| WithRange(e.into(), r.into()))
     }
 }
 

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -314,13 +314,14 @@ impl<'a> Frontend<'a> {
             start: code_block_cskvp_range.end - lang.len(),
             end: code_block_cskvp_range.end,
         };
-        dbg!((&lang, code_block_cskvp_range));
 
         // check if language has label/config
         let language;
         let language_range;
         if let Some(pos) = lang.find(',') {
-            let (l, rest) = lang.split_at(pos);
+            let (l, mut rest) = lang.split_at(pos);
+            // get rid of comma
+            rest.truncate_start(1);
             language = l;
             language_range = SourceRange {
                 start: code_block_cskvp_range.start,


### PR DESCRIPTION
Fix #79 

This fixes crashes of the frontend on the following code, which resulted in pulldown-cmark's unescaping to transform the borrow into an owned string (I don't like GFM unescaping the *info_string*).
````
```rust, foo="\"bar\""
```
````

It also fixes two crashes in cskvp for the following two cases (incorrect delimiter in kvps and in values respectively)
````
```rust, foo=""bar
```

```rust, ""foo
```
````

Error diagnostic of the first case of cskvp:

```rust
error: invalid comma seperated key value pair
- foo.md:1:10
  |
1 | ```rust, foo=""bar""
  |          ------ in this key value pair
  |
- foo.md:1:16
  |
1 | ```rust, foo=""bar""
  |                ^ incorrect delimiter after value
  |
help: try using `,` instead
```