### PR TITLE
Use includegraphics instead of includepdf in Beamer

### DIFF
--- a/src/backend/latex/document/beamer.rs
+++ b/src/backend/latex/document/beamer.rs
@@ -96,7 +96,7 @@ impl<'a> Backend<'a> for Beamer {
     type InterLink = latex::InterLinkGen;
     type Image = latex::ImageGen;
     type Label = latex::LabelGen;
-    type Pdf = latex::PdfGen;
+    type Pdf = latex::BeamerPdfGen;
     type SoftBreak = latex::SoftBreakGen;
     type HardBreak = latex::HardBreakGen;
     type TaskListMarker = latex::TaskListMarkerGen;

--- a/src/backend/latex/mod.rs
+++ b/src/backend/latex/mod.rs
@@ -25,6 +25,7 @@ use self::simple::{
     ListOfListingsGen,
     ListOfTablesGen,
     PdfGen,
+    BeamerPdfGen,
     SoftBreakGen,
     TableOfContentsGen,
     TaskListMarkerGen,

--- a/src/backend/latex/simple.rs
+++ b/src/backend/latex/simple.rs
@@ -208,6 +208,18 @@ impl SimpleCodeGenUnit<Pdf> for PdfGen {
 }
 
 #[derive(Debug)]
+pub struct BeamerPdfGen;
+
+impl SimpleCodeGenUnit<Pdf> for BeamerPdfGen {
+    fn gen(pdf: WithRange<Pdf>, out: &mut impl Write) -> Result<()> {
+        let WithRange(Pdf { path }, _range) = pdf;
+
+        writeln!(out, "\\includegraphics{{{}}}", path.display())?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
 pub struct SoftBreakGen;
 
 impl SimpleCodeGenUnit<()> for SoftBreakGen {


### PR DESCRIPTION
`\includepdf` is not compatible with `beamer` <https://tex.stackexchange.com/a/11461>. Use `\includegraphics` instead.