### PR TITLE
Forward all unknown attributes to latex lstlistings

### DIFF
--- a/src/backend/latex/complex/codeblock.rs
+++ b/src/backend/latex/complex/codeblock.rs
@@ -16,7 +16,7 @@ impl<'a> CodeGenUnit<'a, CodeBlock<'a>> for CodeBlockGen {
         _cfg: &'a Config, code_block: WithRange<CodeBlock<'a>>,
         gen: &mut Generator<'a, impl Backend<'a>, impl Write>,
     ) -> Result<Self> {
-        let WithRange(CodeBlock { label, caption, language }, _range) = code_block;
+        let WithRange(CodeBlock { label, caption, language, attributes }, _range) = code_block;
 
         let mut out = gen.get_out();
         write!(out, "\\begin{{lstlisting}}[")?;
@@ -34,6 +34,11 @@ impl<'a> CodeGenUnit<'a, CodeBlock<'a>> for CodeBlockGen {
                 lang => lang
             };
             joiner.join(format_args!("language={{{}}}", language))?;
+        }
+        if !attributes.is_empty() {
+            for (k, v) in attributes {
+                joiner.join(format_args!("{}={{{}}}", k, v.0))?;
+            }
         }
         writeln!(out, "]")?;
 

--- a/src/cskvp.rs
+++ b/src/cskvp.rs
@@ -160,6 +160,10 @@ impl<'a> Cskvp<'a> {
         self.double.remove(key)
     }
 
+    pub fn take_all_double(&mut self) -> HashMap<Cow<'a, str>, WithRange<Cow<'a, str>>> {
+        self.double.drain().collect()
+    }
+
     /// Removes all elements from `self`.
     ///
     /// This can be used before dropping `Cskvp` to omit all "unused attribute" warnings.
@@ -179,7 +183,7 @@ impl<'a> Drop for Cskvp<'a> {
         let mut diag = self
             .diagnostics
             .as_mut()
-            .map(|d| d.warning("unknown attributes in element config")
+            .map(|d| d.warning("unused / unknown attributes in element config")
                 .with_info_section(range, "in this element config"));
         if let Some(WithRange(label, range)) = self.label.take() {
             diag = diag.map(|d| {

--- a/src/frontend/event.rs
+++ b/src/frontend/event.rs
@@ -6,6 +6,7 @@ use enum_kinds::EnumKind;
 
 use crate::frontend::range::WithRange;
 use crate::resolve::{Command, ResolveSecurity};
+use std::collections::HashMap;
 
 // extension of pulldown_cmark::Event with custom types
 #[derive(Debug, EnumKind)]
@@ -111,6 +112,7 @@ pub struct CodeBlock<'a> {
     pub label: Option<WithRange<Cow<'a, str>>>,
     pub caption: Option<WithRange<Cow<'a, str>>>,
     pub language: Option<WithRange<Cow<'a, str>>>,
+    pub attributes: HashMap<Cow<'a, str>, WithRange<Cow<'a, str>>>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -460,6 +460,7 @@ impl<'a> Frontend<'a> {
                 } else {
                     Some(WithRange(language, language_range))
                 },
+                attributes: cskvp.take_all_double(),
             }),
         };
 


### PR DESCRIPTION
I used this for a presentation to specify fontsize (`basicstyle=\tiny`)
for listings. Shouldn't be a long-term solution in general, so unsure if
we actually want to merge this?