### PR TITLE
Add an espeak+video backend

### DIFF
--- a/examples/mp4.md
+++ b/examples/mp4.md
@@ -1,0 +1,89 @@
+```heradoc
+output_type = "mp4"
+document_type = "beamer"
+titlepage = false
+sectionframes = false
+```
+
+# The basics
+## Introduction
+
+```espeak
+Hello. Today, we will see something awesome. We know already that Heradoc is
+useful for quickly creating feature rich presentations in an academic setting
+where graphcs, code, and formulas are an absolute must. But now, we truly
+witness the next leap.
+```
+
+Markdown + Text + TextToSpeech = awesome
+
+## Motivation and the fundamental attribution error
+
+```espeak
+How did this project happen? There are a few causes that come to mind. First of
+all, the coronavirus quarantine necessitating video conferences and canceling
+all other presentations. Secondly, I recently got aware of someone posting
+something like this in a software as a service model over the internet. This
+waste of resources, privacy, and general finess _must_ be fought and what
+better way than make it available with a libre Markdown converter? But let's
+not forget another grave factor, that I can't control myself and waste time on
+project such as these that have little real personal gains.
+
+But that does not really explain it. The reality is probably even more
+complicated. You almost surely underestimate the situational explanations
+leading to this situation, and so do I. Think about it, what are the chances
+that some developer for an infant obscure program for personal sue took the
+time to hack together text-to-speech just for the sake of making a single
+presentation as an april's fool joke? Jeez.
+```
+
+How did this project ever happen?
+
+* The coronavirus quarantine
+* Someone offering this via the internet as software as a service
+* A distaste for spending my time sensibly
+
+# What we use language for
+## An ode to TTS
+
+```espeak
+Humans like to communicate through speech, it allows us to articular our most
+profound ideas. Through conversation do we birth fantastical ideas. And true
+masters, poets, gain eternal life. But humans are fallible. In comparison, Text
+to speech can't fail. Unlike humans it does not get ill. It is consistent, it
+does not make mistakes:
+
+Peter Piper picked a peck of pickled peppers. How many pickled peppers did Peter Piper pick?
+
+That wasn't so hard now, was it?
+
+It's never gonna give you up,
+never gonna let you down,
+never gonna run around and desert you.
+```
+
+Language is a powerful way of conveying ideas.
+
+Poets are under the most well-known historical figures for a reason.
+
+## And this is where we get meta
+
+```espeak
+But language is also a great tool for deception. It can be used for evil. Did
+any of this talk make sense to you? Maybe it shouldn't. When DeepL and other
+neural networks can create good translations themselves how hard can it be to
+run some final style checks on a finished script to ensure it aligns to a
+message regardless of the actual author, who may be a poor mechanical turk
+somewhere? A very bad example:
+
+Hello, fellow [NON HETEROSEXUAL]. It is us, [MULTI-BILLION DOLLAR CORPORATION]. Here
+to remind you that we support your lifestyle now that it has been federally
+legalised and it is completely socially safe, allowing for us to capitalise on
+your existence now it's mainstream. Look, we even changed the colours of
+[LOGO]! Why did we wait this long to come out and 'support' you? Haha, no more
+questions, [FELLOW HUMAN]. Buy our product. Buy our product. BUY OUR PRODUCT.
+```
+
+It's a tool to be coaxed and deceived. Not always maliciously.
+
+A small amount of lies mixed with truth is very effective.

--- a/src/backend/ffmpeg/mod.rs
+++ b/src/backend/ffmpeg/mod.rs
@@ -1,0 +1,146 @@
+use std::borrow::Cow;
+use std::io::{self, Write};
+
+use crate::backend::latex::{self, Beamer};
+use crate::backend::{Backend, CodeGenUnit, StatefulCodeGenUnit};
+use crate::config::Config;
+use crate::diagnostics::Diagnostics;
+use crate::error::{FatalResult, Result};
+use crate::frontend::range::{WithRange, SourceRange};
+use crate::generator::event::{Event, Header};
+use crate::generator::Generator;
+
+#[derive(Debug)]
+pub struct SlidesFfmpegEspeak {
+    slides: Beamer,
+}
+
+#[rustfmt::skip]
+impl<'a> Backend<'a> for SlidesFfmpegEspeak {
+    type Text = <Beamer as Backend<'a>>::Text;
+    type Latex = <Beamer as Backend<'a>>::Latex;
+    type FootnoteReference = <Beamer as Backend<'a>>::FootnoteReference;
+    type BiberReferences = <Beamer as Backend<'a>>::BiberReferences;
+    type Url = <Beamer as Backend<'a>>::Url;
+    type InterLink = <Beamer as Backend<'a>>::InterLink;
+    type Image = <Beamer as Backend<'a>>::Image;
+    type Svg = <Beamer as Backend<'a>>::Svg;
+    type Label = <Beamer as Backend<'a>>::Label;
+    type Pdf = <Beamer as Backend<'a>>::Pdf;
+    type SoftBreak = <Beamer as Backend<'a>>::SoftBreak;
+    type HardBreak = <Beamer as Backend<'a>>::HardBreak;
+    type TaskListMarker = <Beamer as Backend<'a>>::TaskListMarker;
+    type TableOfContents = <Beamer as Backend<'a>>::TableOfContents;
+    type Bibliography = <Beamer as Backend<'a>>::Bibliography;
+    type ListOfTables = <Beamer as Backend<'a>>::ListOfTables;
+    type ListOfFigures = <Beamer as Backend<'a>>::ListOfFigures;
+    type ListOfListings = <Beamer as Backend<'a>>::ListOfListings;
+    type Appendix = <Beamer as Backend<'a>>::Appendix;
+
+    type Paragraph = <Beamer as Backend<'a>>::Paragraph;
+    type Rule = PseudoBeamerRuleGen<'a>;
+    type Header = PseudoBeamerHeaderGen<'a>;
+    type BlockQuote = <Beamer as Backend<'a>>::BlockQuote;
+    type CodeBlock = <Beamer as Backend<'a>>::CodeBlock;
+    type List = <Beamer as Backend<'a>>::List;
+    type Enumerate = <Beamer as Backend<'a>>::Enumerate;
+    type Item = <Beamer as Backend<'a>>::Item;
+    type FootnoteDefinition = <Beamer as Backend<'a>>::FootnoteDefinition;
+    type UrlWithContent = <Beamer as Backend<'a>>::UrlWithContent;
+    type InterLinkWithContent = <Beamer as Backend<'a>>::InterLinkWithContent;
+    type HtmlBlock = <Beamer as Backend<'a>>::HtmlBlock;
+    type Figure = <Beamer as Backend<'a>>::Figure;
+
+    type TableFigure = <Beamer as Backend<'a>>::TableFigure;
+    type Table = <Beamer as Backend<'a>>::Table;
+    type TableHead = <Beamer as Backend<'a>>::TableHead;
+    type TableRow = <Beamer as Backend<'a>>::TableRow;
+    type TableCell = <Beamer as Backend<'a>>::TableCell;
+
+    type InlineEmphasis = <Beamer as Backend<'a>>::InlineEmphasis;
+    type InlineStrong = <Beamer as Backend<'a>>::InlineStrong;
+    type InlineStrikethrough = <Beamer as Backend<'a>>::InlineStrikethrough;
+    type InlineCode = <Beamer as Backend<'a>>::InlineCode;
+    type InlineMath = <Beamer as Backend<'a>>::InlineMath;
+
+    type Equation = <Beamer as Backend<'a>>::Equation;
+    type NumberedEquation = <Beamer as Backend<'a>>::NumberedEquation;
+    type Graphviz = <Beamer as Backend<'a>>::Graphviz;
+
+    fn new() -> Self {
+        SlidesFfmpegEspeak {
+            slides: Beamer::new(),
+        }
+    }
+
+    fn gen_preamble(&mut self, cfg: &Config, mut out: &mut impl Write, diagnostics: &Diagnostics<'a>) -> FatalResult<()> {
+        self.slides.gen_preamble(cfg, out, diagnostics)
+    }
+
+    fn gen_epilogue(&mut self, cfg: &Config, out: &mut impl Write, diagnostics: &Diagnostics<'a>) -> FatalResult<()> {
+        self.slides.gen_epilogue(cfg, out, diagnostics)
+    }
+}
+
+#[derive(Debug)]
+pub struct PseudoBeamerRuleGen<'a> {
+    cfg: &'a Config,
+    range: SourceRange,
+}
+
+impl<'a> StatefulCodeGenUnit<'a, SlidesFfmpegEspeak, ()> for PseudoBeamerRuleGen<'a> {
+    fn new(
+        cfg: &'a Config, WithRange(_, range): WithRange<()>,
+        _gen: &mut Generator<'a, SlidesFfmpegEspeak, impl Write>,
+    ) -> Result<Self> {
+        Ok(PseudoBeamerRuleGen { cfg, range })
+    }
+
+    fn finish(
+        self, gen: &mut Generator<'a, SlidesFfmpegEspeak, impl Write>,
+        _peek: Option<WithRange<&Event<'a>>>,
+    ) -> Result<()> {
+        let PseudoBeamerRuleGen { cfg, range } = self;
+        let (diagnostics, backend, mut out) = gen.backend_and_out();
+        backend.slides.close_until(2, &mut out, range, diagnostics)?;
+        backend.slides.open_until(2, cfg, &mut out, range, diagnostics)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct PseudoBeamerHeaderGen<'a> {
+    cfg: &'a Config,
+    level: i32,
+    label: WithRange<Cow<'a, str>>,
+    range: SourceRange,
+}
+
+impl<'a> StatefulCodeGenUnit<'a, SlidesFfmpegEspeak, Header<'a>> for PseudoBeamerHeaderGen<'a> {
+    fn new(
+        cfg: &'a Config, header: WithRange<Header<'a>>,
+        gen: &mut Generator<'a, SlidesFfmpegEspeak, impl Write>,
+    ) -> Result<Self> {
+        let (diagnostics, backend, mut out) = gen.backend_and_out();
+        let WithRange(Header { label, level }, range) = header;
+
+        // close old slide / beamerboxesrounded
+        backend.slides.close_until(level, &mut out, range, diagnostics)?;
+
+        write!(out, "\\{}section{{", "sub".repeat(level as usize - 1))?;
+
+        Ok(PseudoBeamerHeaderGen { cfg, level, label, range })
+    }
+
+    fn finish(
+        self, gen: &mut Generator<'a, SlidesFfmpegEspeak, impl Write>,
+        _peek: Option<WithRange<&Event<'a>>>,
+    ) -> Result<()> {
+        let PseudoBeamerHeaderGen { cfg, level, label, range } = self;
+        let (diagnostics, backend, mut out) = gen.backend_and_out();
+        writeln!(out, "}}\\label{{{}}}\n", label.0)?;
+
+        backend.slides.open_until(level, cfg, &mut out, range, diagnostics)?;
+        Ok(())
+    }
+}

--- a/src/backend/ffmpeg/mod.rs
+++ b/src/backend/ffmpeg/mod.rs
@@ -100,7 +100,7 @@ impl SlidesFfmpegEspeak {
             Ok(file) => Ok(file),
             Err(e) => {
                 diagnostics
-                    .error("error creating temporary espeak file for frame")
+                    .error(format!("error creating espeak file `{}` for frame {}", p.display(), i))
                     .note(format!("cause: {}", e))
                     .note("this is fatal")
                     .emit();

--- a/src/backend/ffmpeg/mod.rs
+++ b/src/backend/ffmpeg/mod.rs
@@ -119,7 +119,7 @@ impl CurrentFrame {
 impl Extend<BeamerFrameEvent> for CurrentFrame {
     fn extend<Iter: IntoIterator<Item=BeamerFrameEvent>>(&mut self, iter: Iter) {
         for item in iter {
-            if let BeamerFrameEvent::BeginFrame = item {
+            if let BeamerFrameEvent::EndFrame = item {
                 self.0 += 1;
             }
         }

--- a/src/backend/latex/document/mod.rs
+++ b/src/backend/latex/document/mod.rs
@@ -4,6 +4,6 @@ mod report;
 mod thesis;
 
 pub use self::article::Article;
-pub use self::beamer::Beamer;
+pub use self::beamer::{Beamer, FrameEvent as BeamerFrameEvent};
 pub use self::report::Report;
 pub use self::thesis::Thesis;

--- a/src/backend/latex/mod.rs
+++ b/src/backend/latex/mod.rs
@@ -7,7 +7,7 @@ mod preamble;
 mod replace;
 mod simple;
 
-pub use self::document::{Article, Beamer, Report, Thesis};
+pub use self::document::{Article, Beamer, BeamerFrameEvent, Report, Thesis};
 
 use crate::frontend::range::WithRange;
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -32,6 +32,7 @@ use crate::generator::event::{
 use crate::generator::{Generator, Stack};
 
 pub mod latex;
+pub mod ffmpeg;
 
 pub fn generate<'a>(
     cfg: &'a Config, backend: impl Backend<'a>, arena: &'a Arena<String>, markdown: String,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -268,6 +268,7 @@ impl Config {
                 match output_type {
                     OutType::Latex => assert!(filename.set_extension("tex")),
                     OutType::Pdf => assert!(filename.set_extension("pdf")),
+                    OutType::Mp4 => assert!(filename.set_extension("mp4")),
                 }
                 FileOrStdio::File(filename)
             },
@@ -529,6 +530,7 @@ impl FromStr for FileOrStdio {
 pub enum OutType {
     Latex,
     Pdf,
+    Mp4,
 }
 
 impl<'de> Deserialize<'de> for OutType {
@@ -546,6 +548,8 @@ impl FromStr for OutType {
             Ok(OutType::Latex)
         } else if s.eq_ignore_ascii_case("pdf") {
             Ok(OutType::Pdf)
+        } else if s.eq_ignore_ascii_case("mp4") || s.eq_ignore_ascii_case("ffmpeg") {
+            Ok(OutType::Mp4)
         } else {
             Err(format!("unknown output type {:?}", s))
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,7 @@ fn ffmpeg<P: AsRef<Path>>(pdf: P, cfg: &Config) -> PathBuf {
             .arg(&speak)
             .arg("-w")
             .arg(&wav)
+            .args(&["-v", "Henrique"])
             .status()
             .expect("Conversion with `espeak-ng` failed.");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ fn ffmpeg<P: AsRef<Path>>(pdf: P, cfg: &Config) -> PathBuf {
     // /rant
     Command::new("pdftoppm")
         .current_dir(&cfg.out_dir)
-        .arg("-png")
+        .args(&["-png", "-rx", "600", "-ry", "600"])
         .arg(pdf.as_ref())
         .arg("pages")
         .status()


### PR DESCRIPTION
Depends on external programs `ffmpeg`, `sox` and `espeak-ng`. Example in `examples/mp4.md`.