### PR TITLE
Update str-concat version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "single 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "str-concat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "str-concat 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2127,7 +2127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "str-concat"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2911,7 +2911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-"checksum str-concat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "64fdc54cf225600eb1177c62d93662b4eb2ed25153523c018244be9322adff1e"
+"checksum str-concat 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3468939e48401c4fe3cdf5e5cef50951c2808ed549d1467fde249f1fcb602634"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
 "checksum string_cache_codegen 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 pulldown-cmark = "0.4.0"
-str-concat = "0.1.4"
+str-concat = "0.2.0"
 structopt = "0.2.10"
 void = "1.0.2"
 boolinator = "2.4"

--- a/src/frontend/concat.rs
+++ b/src/frontend/concat.rs
@@ -42,7 +42,8 @@ impl<'a> Iterator for Concat<'a> {
 
             match t {
                 Cow::Borrowed(b) => match next {
-                    Cow::Borrowed(next) => match str_concat::concat(b, next) {
+                    // SAFETY: it's from the same allocation, namely the same file-string
+                    Cow::Borrowed(next) => match unsafe { str_concat::concat(b, next) } {
                         Ok(res) => t = Cow::Borrowed(res),
                         Err(_) => t = Cow::Owned(b.to_string() + next),
                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-#![forbid(unsafe_code)]
+// FIXME: See #134
+//#![forbid(unsafe_code)]
 // groups
 #![warn(nonstandard_style)]
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
Fix #133 

Unfortunately, we aren't `#![forbid(unsafe_code)]` anymore, but technically we already weren't it by using an unsound function before.